### PR TITLE
Standardize namespace usage across Application and Common components

### DIFF
--- a/Application/Authentication/AuthenticationService.cpp
+++ b/Application/Authentication/AuthenticationService.cpp
@@ -9,6 +9,8 @@
 
 namespace Etrek::Application::Authentication
 {
+    using Etrek::Specification::Result;
+
     AuthenticationService::AuthenticationService(const AuthenticationRepository& repository,
         const CryptoManager& securityService,
         QObject* parent)

--- a/Application/Authentication/AuthenticationService.h
+++ b/Application/Authentication/AuthenticationService.h
@@ -14,6 +14,8 @@ using namespace Etrek::Core::Repository;
 
 namespace Etrek::Application::Authentication {
 
+    using Etrek::Specification::Result;
+
     class AuthenticationService : public QObject
     {
         Q_OBJECT

--- a/Application/Delegate/MainWindowDelegate.cpp
+++ b/Application/Delegate/MainWindowDelegate.cpp
@@ -3,77 +3,82 @@
 #include "MainWindowDelegate.h"
 #include "SystemSettingPageBuilder.h"
 
-using namespace Etrek::Application::Delegate;
-
-MainWindowDelegate::MainWindowDelegate(const DelegateParameter& params, MainWindow* widget, QObject* parent)
-    : QObject(parent),
-      m_params(params),
-      m_mainWindow(widget)
+namespace Etrek::Application::Delegate
 {
-    Q_ASSERT(m_mainWindow);
-
-    // Connect MainWindow's custom signals to delegate slots
-    connect(m_mainWindow, &MainWindow::LoadSystemPageAction,
-        this, &MainWindowDelegate::onLoadSystemPageAction);
-    connect(m_mainWindow, &MainWindow::aboutToClose,
-        this, &MainWindowDelegate::aboutToClose);
-    connect(m_mainWindow, &QObject::destroyed, this, [this]()
-        {
-            m_mainWindow = nullptr;
-        });
-
-    // If you later add more:
-    // connect(m_mainWindow, &MainWindow::LoadExamPage,   this, &MainWindowDelegate::onLoadExamPage);
-    // connect(m_mainWindow, &MainWindow::LoadViewPage,   this, &MainWindowDelegate::onLoadViewPage);
-    // connect(m_mainWindow, &MainWindow::LoadOutputPage, this, &MainWindowDelegate::onLoadOutputPage);
-}
-
-void MainWindowDelegate::onLoadSystemPageAction()
-{
-    if (!m_mainWindow) {
-        qWarning() << "MainWindowDelegate::onLoadSystemPageAction invoked without a MainWindow instance.";
-        return;
-    }
-
-    m_mainWindow->prepareLoadingPage();
-
-    if (m_systemSettingPageDelegate)
+    MainWindowDelegate::MainWindowDelegate(const DelegateParameter& params, MainWindow* widget, QObject* parent)
+        : QObject(parent),
+        m_params(params),
+        m_mainWindow(widget)
     {
-        m_systemSettingPageDelegate->deleteLater();
-        m_systemSettingPageDelegate = nullptr;
-    }
+        Q_ASSERT(m_mainWindow);
 
-    SystemSettingPageBuilder builder;
-    auto result = builder.build(m_params, nullptr, this);
-    auto* page = result.first;
-    m_systemSettingPageDelegate = result.second;
-
-    if (m_systemSettingPageDelegate) {
-        connect(m_systemSettingPageDelegate, &SystemSettingPageDelegate::closeSettings,
-            this, [page, this]()
+        // Connect MainWindow's custom signals to delegate slots
+        connect(m_mainWindow, &MainWindow::LoadSystemPageAction,
+            this, &MainWindowDelegate::onLoadSystemPageAction);
+        connect(m_mainWindow, &MainWindow::aboutToClose,
+            this, &MainWindowDelegate::aboutToClose);
+        connect(m_mainWindow, &QObject::destroyed, this, [this]()
             {
-                if (m_mainWindow) {
-                    m_mainWindow->closePage();
-                }
+                m_mainWindow = nullptr;
             });
+
+        // If you later add more:
+        // connect(m_mainWindow, &MainWindow::LoadExamPage,   this, &MainWindowDelegate::onLoadExamPage);
+        // connect(m_mainWindow, &MainWindow::LoadViewPage,   this, &MainWindowDelegate::onLoadViewPage);
+        // connect(m_mainWindow, &MainWindow::LoadOutputPage, this, &MainWindowDelegate::onLoadOutputPage);
     }
 
-    if (m_mainWindow) {
-        m_mainWindow->loadPage(page);
-        m_mainWindow->finishLoadingPage();
+    void MainWindowDelegate::onLoadSystemPageAction()
+    {
+        if (!m_mainWindow)
+        {
+            qWarning() << "MainWindowDelegate::onLoadSystemPageAction invoked without a MainWindow instance.";
+            return;
+        }
+
+        m_mainWindow->prepareLoadingPage();
+
+        if (m_systemSettingPageDelegate)
+        {
+            m_systemSettingPageDelegate->deleteLater();
+            m_systemSettingPageDelegate = nullptr;
+        }
+
+        SystemSettingPageBuilder builder;
+        auto result = builder.build(m_params, nullptr, this);
+        auto* page = result.first;
+        m_systemSettingPageDelegate = result.second;
+
+        if (m_systemSettingPageDelegate)
+        {
+            connect(m_systemSettingPageDelegate, &SystemSettingPageDelegate::closeSettings,
+                this, [page, this]()
+                {
+                    if (m_mainWindow)
+                    {
+                        m_mainWindow->closePage();
+                    }
+                });
+        }
+
+        if (m_mainWindow)
+        {
+            m_mainWindow->loadPage(page);
+            m_mainWindow->finishLoadingPage();
+        }
     }
+
+    void MainWindowDelegate::show()
+    {
+        if (!m_mainWindow)
+        {
+            qWarning() << "MainWindowDelegate::show called without a MainWindow instance.";
+            return;
+        }
+
+        m_mainWindow->show();
+    }
+
+    MainWindowDelegate::~MainWindowDelegate() = default;
 }
-
-void MainWindowDelegate::show()
-{
-    if (!m_mainWindow) {
-        qWarning() << "MainWindowDelegate::show called without a MainWindow instance.";
-        return;
-    }
-
-    m_mainWindow->show();
-}
-
-MainWindowDelegate::~MainWindowDelegate()
-{}
 

--- a/Application/Delegate/MainWindowDelegate.h
+++ b/Application/Delegate/MainWindowDelegate.h
@@ -7,27 +7,30 @@
 #include "MainWindow.h"
 #include "DelegateParameter.h"
 
-class MainWindowDelegate : public QObject
+namespace Etrek::Application::Delegate
 {
-	Q_OBJECT
+    class MainWindowDelegate : public QObject
+    {
+        Q_OBJECT
 
-public:
-	MainWindowDelegate(const DelegateParameter& params,MainWindow* widget, QObject* parent);
-	
-	void show();
+    public:
+        MainWindowDelegate(const DelegateParameter& params, MainWindow* widget, QObject* parent);
 
-	~MainWindowDelegate();
+        void show();
 
-signals:
-	void aboutToClose();
+        ~MainWindowDelegate();
 
-private slots:
-	void onLoadSystemPageAction();
+    signals:
+        void aboutToClose();
 
-private:
-	SystemSettingPageDelegate* m_systemSettingPageDelegate{ nullptr };
-	MainWindow* m_mainWindow{ nullptr };
-	DelegateParameter m_params;
-};
+    private slots:
+        void onLoadSystemPageAction();
+
+    private:
+        SystemSettingPageDelegate* m_systemSettingPageDelegate{ nullptr };
+        MainWindow* m_mainWindow{ nullptr };
+        DelegateParameter m_params;
+    };
+}
 
 #endif // MAINWINDOWDELEGATE_H

--- a/Application/Delegate/SystemSettingPageDelegate.cpp
+++ b/Application/Delegate/SystemSettingPageDelegate.cpp
@@ -1,57 +1,63 @@
 #include "SystemSettingPageDelegate.h"
-#include "SystemSettingPageDelegate.h"
 #include "SystemSettingPage.h"
-#include <QObject>
 
-SystemSettingPageDelegate::SystemSettingPageDelegate(SystemSettingPage* page, QObject* parent)
-	: QObject(parent), 	 
-	  m_page(page)
+namespace Etrek::Application::Delegate
 {
-    connect(page, &SystemSettingPage::saveSettings, this, &SystemSettingPageDelegate::accept);
-    connect(page, &SystemSettingPage::applySettings, this, &SystemSettingPageDelegate::apply);
-    connect(page, &SystemSettingPage::closeSettings, this, &SystemSettingPageDelegate::reject);
-   
-
-}
-
-
-
-SystemSettingPageDelegate::~SystemSettingPageDelegate()
-{}
-
-QString SystemSettingPageDelegate::name() const
-{
-	return QString();
-}
-
-void SystemSettingPageDelegate::attachDelegates(const QVector<QObject*>& list)
-{
-    for (auto* o : list)
-        if (!delegates.contains(o)) delegates.append(QPointer<QObject>(o));
-}
-
-SystemSettingPage* SystemSettingPageDelegate::GetPage() const
-{
-    return m_page;
-}
-
-
-void SystemSettingPageDelegate::apply()
-{
-    for (const auto& p : delegates) {
-        if (!p) continue;                            // auto-nulled on delete
-        if (auto* act = qobject_cast<IPageAction*>(p.data())) act->apply();
+    SystemSettingPageDelegate::SystemSettingPageDelegate(SystemSettingPage* page, QObject* parent)
+        : QObject(parent),
+        m_page(page)
+    {
+        connect(page, &SystemSettingPage::saveSettings, this, &SystemSettingPageDelegate::accept);
+        connect(page, &SystemSettingPage::applySettings, this, &SystemSettingPageDelegate::apply);
+        connect(page, &SystemSettingPage::closeSettings, this, &SystemSettingPageDelegate::reject);
     }
-}
 
-void SystemSettingPageDelegate::accept()
-{
-    //m_page->closePage();
-    // do save operation here
-	emit closeSettings(); // Notify that settings are saved
-}
+    SystemSettingPageDelegate::~SystemSettingPageDelegate() = default;
 
-void SystemSettingPageDelegate::reject()
-{
+    QString SystemSettingPageDelegate::name() const
+    {
+        return QString();
+    }
+
+    void SystemSettingPageDelegate::attachDelegates(const QVector<QObject*>& list)
+    {
+        for (auto* o : list)
+        {
+            if (!delegates.contains(o))
+            {
+                delegates.append(QPointer<QObject>(o));
+            }
+        }
+    }
+
+    SystemSettingPage* SystemSettingPageDelegate::GetPage() const
+    {
+        return m_page;
+    }
+
+    void SystemSettingPageDelegate::apply()
+    {
+        for (const auto& delegatePtr : delegates)
+        {
+            if (!delegatePtr)
+            {
+                continue;
+            }
+
+            if (auto* action = qobject_cast<IPageAction*>(delegatePtr.data()))
+            {
+                action->apply();
+            }
+        }
+    }
+
+    void SystemSettingPageDelegate::accept()
+    {
+        emit closeSettings();
+    }
+
+    void SystemSettingPageDelegate::reject()
+    {
+    }
 }
 

--- a/Application/Delegate/SystemSettingPageDelegate.h
+++ b/Application/Delegate/SystemSettingPageDelegate.h
@@ -8,33 +8,37 @@
 #include "IPageAction.h"
 #include "SystemSettingPage.h"
 
-class SystemSettingPageDelegate : 
-	public QObject,
-	public IDelegate,
-	public IPageAction
+namespace Etrek::Application::Delegate
 {
-	Q_OBJECT
-	Q_INTERFACES(IDelegate IPageAction)
+    class SystemSettingPageDelegate :
+        public QObject,
+        public IDelegate,
+        public IPageAction
+    {
+        Q_OBJECT
+        Q_INTERFACES(IDelegate IPageAction)
 
-public:
-	SystemSettingPageDelegate(SystemSettingPage* page,QObject *parent);
-	
-	QString name() const override;
-	void attachDelegates(const QVector<QObject*>& delegates) override;
-	SystemSettingPage* GetPage() const;
-	~SystemSettingPageDelegate();
+    public:
+        SystemSettingPageDelegate(SystemSettingPage* page, QObject* parent);
 
-signals:
-	void closeSettings();
-public slots:
-	void apply() override;
-	void accept() override;
-	void reject() override;
+        QString name() const override;
+        void attachDelegates(const QVector<QObject*>& delegates) override;
+        SystemSettingPage* GetPage() const;
+        ~SystemSettingPageDelegate();
 
-private:
-	SystemSettingPage* m_page;
-	QVector<QPointer<QObject>> delegates;
-};
+    signals:
+        void closeSettings();
+
+    public slots:
+        void apply() override;
+        void accept() override;
+        void reject() override;
+
+    private:
+        SystemSettingPage* m_page;
+        QVector<QPointer<QObject>> delegates;
+    };
+}
 
 
 #endif // SYSTEMSETTINGPAGEDELEGATE_H

--- a/Application/Service/ApplicationService.cpp
+++ b/Application/Service/ApplicationService.cpp
@@ -23,8 +23,11 @@
 
 using namespace Etrek::Application::Authentication;
 using namespace Etrek::Application::Delegate;
+
 namespace Etrek::Application::Service
 {
+    using Etrek::Specification::LaunchMode;
+    using Etrek::Specification::Result;
     ApplicationService::ApplicationService(QObject* parent)
         : QObject{ parent }
     {

--- a/Application/Service/ApplicationService.h
+++ b/Application/Service/ApplicationService.h
@@ -31,6 +31,8 @@ using namespace Etrek::Worklist::Connectivity;
 
 namespace Etrek::Application::Service
 {
+    using Etrek::Specification::LaunchMode;
+
     class ApplicationService : public QObject
     {
         Q_OBJECT

--- a/Common/Include/Specification/LaunchMode.h
+++ b/Common/Include/Specification/LaunchMode.h
@@ -4,22 +4,25 @@
 #include <QStringList>
 
 
-enum class LaunchMode {
-    MainApp,
-    UserManager,
-    SettingManager,
-    Demo,
-	Developer,
-    Unknown
-};
+namespace Etrek::Specification
+{
+    enum class LaunchMode {
+        MainApp,
+        UserManager,
+        SettingManager,
+        Demo,
+        Developer,
+        Unknown
+    };
 
 
-inline LaunchMode ParseLaunchMode(const QStringList& args) {
-    if (args.contains("usermgr", Qt::CaseInsensitive)) return LaunchMode::UserManager;
-    if (args.contains("settingmgr", Qt::CaseInsensitive)) return LaunchMode::SettingManager;
-    if (args.contains("demo", Qt::CaseInsensitive)) return LaunchMode::Demo;
-	if (args.contains("developer", Qt::CaseInsensitive)) return LaunchMode::Developer;
+    inline LaunchMode ParseLaunchMode(const QStringList& args) {
+        if (args.contains("usermgr", Qt::CaseInsensitive)) return LaunchMode::UserManager;
+        if (args.contains("settingmgr", Qt::CaseInsensitive)) return LaunchMode::SettingManager;
+        if (args.contains("demo", Qt::CaseInsensitive)) return LaunchMode::Demo;
+        if (args.contains("developer", Qt::CaseInsensitive)) return LaunchMode::Developer;
 
-    return LaunchMode::MainApp;
+        return LaunchMode::MainApp;
+    }
 }
 #endif // LAUNCHMODE_H

--- a/Common/Include/Specification/Result.h
+++ b/Common/Include/Specification/Result.h
@@ -7,84 +7,87 @@
 #include <QVariant>
 #include <type_traits>
 
-// ====================== Generic Result<T> ======================
-template <typename T>
-class Result
+namespace Etrek::Specification
 {
-public:
-    bool isSuccess = false;
-    QString message;
-    T value;
-
-    Result() = default;
-
-    Result(bool success, const QString& msg, const T& val)
-        : isSuccess(success), message(msg), value(val) {
-    }
-
-    static Result<T> Success(const T& val, const QString& msg = "Success")
+    // ====================== Generic Result<T> ======================
+    template <typename T>
+    class Result
     {
-        return Result<T>(true, msg, val);
-    }
+    public:
+        bool isSuccess = false;
+        QString message;
+        T value;
 
-    static Result<T> Failure(const QString& msg)
-    {
-        return Result<T>(false, msg, T{});
-    }
+        Result() = default;
 
-    QJsonObject toJson() const
-    {
-        QJsonObject obj;
-        obj["isSuccess"] = isSuccess;
-        obj["message"] = message;
-
-        if constexpr (std::is_same_v<T, QString>) {
-            obj["value"] = value;
-        }
-        else if constexpr (std::is_arithmetic_v<T>) {
-            obj["value"] = QJsonValue::fromVariant(QVariant::fromValue(value));
-        }
-        else {
-            // For complex T you can extend this as needed
-            obj["value"] = QJsonValue("Unsupported");
+        Result(bool success, const QString& msg, const T& val)
+            : isSuccess(success), message(msg), value(val) {
         }
 
-        return obj;
-    }
-};
+        static Result<T> Success(const T& val, const QString& msg = "Success")
+        {
+            return Result<T>(true, msg, val);
+        }
 
-// ====================== Specialization: Result<void> ======================
-template <>
-class Result<void>
-{
-public:
-    bool isSuccess = false;
-    QString message;
+        static Result<T> Failure(const QString& msg)
+        {
+            return Result<T>(false, msg, T{});
+        }
 
-    Result() = default;
+        QJsonObject toJson() const
+        {
+            QJsonObject obj;
+            obj["isSuccess"] = isSuccess;
+            obj["message"] = message;
 
-    Result(bool success, const QString& msg)
-        : isSuccess(success), message(msg) {
-    }
+            if constexpr (std::is_same_v<T, QString>) {
+                obj["value"] = value;
+            }
+            else if constexpr (std::is_arithmetic_v<T>) {
+                obj["value"] = QJsonValue::fromVariant(QVariant::fromValue(value));
+            }
+            else {
+                // For complex T you can extend this as needed
+                obj["value"] = QJsonValue("Unsupported");
+            }
 
-    static Result<void> Success(const QString& msg = "Success")
+            return obj;
+        }
+    };
+
+    // ====================== Specialization: Result<void> ======================
+    template <>
+    class Result<void>
     {
-        return Result<void>(true, msg);
-    }
+    public:
+        bool isSuccess = false;
+        QString message;
 
-    static Result<void> Failure(const QString& msg)
-    {
-        return Result<void>(false, msg);
-    }
+        Result() = default;
 
-    QJsonObject toJson() const
-    {
-        QJsonObject obj;
-        obj["isSuccess"] = isSuccess;
-        obj["message"] = message;
-        obj["value"] = QJsonValue(); // null
-        return obj;
-    }
-};
+        Result(bool success, const QString& msg)
+            : isSuccess(success), message(msg) {
+        }
+
+        static Result<void> Success(const QString& msg = "Success")
+        {
+            return Result<void>(true, msg);
+        }
+
+        static Result<void> Failure(const QString& msg)
+        {
+            return Result<void>(false, msg);
+        }
+
+        QJsonObject toJson() const
+        {
+            QJsonObject obj;
+            obj["isSuccess"] = isSuccess;
+            obj["message"] = message;
+            obj["value"] = QJsonValue(); // null
+            return obj;
+        }
+    };
+}
 
 #endif // RESULT_H

--- a/Common/Include/Worklist/Repository/IWorklistFieldConfigurationRepository.h
+++ b/Common/Include/Worklist/Repository/IWorklistFieldConfigurationRepository.h
@@ -10,6 +10,8 @@
 namespace Etrek::Worklist::Repository
 {
 
+    using Etrek::Specification::Result;
+
     class IWorklistFieldConfigurationRepository
     {
     public:       

--- a/Common/Include/Worklist/Repository/IWorklistRepository.h
+++ b/Common/Include/Worklist/Repository/IWorklistRepository.h
@@ -18,6 +18,8 @@ using namespace Etrek::Worklist::Data::Entity;
 
 namespace Etrek::Worklist::Repository {
 
+    using Etrek::Specification::Result;
+
     /**
      * @class WorklistRepository
      * @brief Provides data access and management for DICOM worklist entries, profiles, and attributes.

--- a/Core/Log/LoggerProvider.cpp
+++ b/Core/Log/LoggerProvider.cpp
@@ -10,6 +10,8 @@
 
 
 namespace Etrek::Core::Log {
+
+    using Etrek::Specification::Result;
     LoggerProvider& LoggerProvider::Instance()
     {
         static LoggerProvider instance;

--- a/Core/Log/LoggerProvider.h
+++ b/Core/Log/LoggerProvider.h
@@ -14,6 +14,8 @@
 using namespace  Etrek::Core::Globalization;
 namespace  Etrek::Core::Log {
 
+    using Etrek::Specification::Result;
+
     /**
      * @class LoggerProvider
      * @brief Provides file-based logging services for the application.

--- a/Core/Repository/AuthenticationRepository.cpp
+++ b/Core/Repository/AuthenticationRepository.cpp
@@ -8,6 +8,8 @@
 
 namespace Etrek::Core::Repository {
 
+    using Etrek::Specification::Result;
+
     AuthenticationRepository::AuthenticationRepository(std::shared_ptr<DatabaseConnectionSetting> connectionSetting, TranslationProvider* tr)
         : m_connectionSetting(std::move(connectionSetting)),
         translator(tr ? tr : &TranslationProvider::Instance()),

--- a/Core/Repository/AuthenticationRepository.h
+++ b/Core/Repository/AuthenticationRepository.h
@@ -19,6 +19,8 @@ using namespace Etrek::Core::Log;
 
 namespace Etrek::Core::Repository {
 
+    using Etrek::Specification::Result;
+
     /**
      * @class AuthenticationRepository
      * @brief Provides methods for user authentication and role management.

--- a/Core/Repository/DatabaseSetupManager.cpp
+++ b/Core/Repository/DatabaseSetupManager.cpp
@@ -11,6 +11,8 @@
 
 namespace Etrek::Core::Repository {
 
+    using Etrek::Specification::Result;
+
     DatabaseSetupManager::DatabaseSetupManager(std::shared_ptr<Model::DatabaseConnectionSetting> connectionSetting)
         :m_connectionSetting(std::move(connectionSetting))
         {

--- a/Core/Repository/DatabaseSetupManager.h
+++ b/Core/Repository/DatabaseSetupManager.h
@@ -14,6 +14,8 @@ using namespace Etrek::Core::Data;
 
 namespace Etrek::Core::Repository {
 
+    using Etrek::Specification::Result;
+
     /**
      * @class DatabaseSetupManager
      * @brief Manages the initialization and setup of the database.

--- a/Device/Repository/DeviceRepository.cpp
+++ b/Device/Repository/DeviceRepository.cpp
@@ -37,7 +37,7 @@ QSqlDatabase DeviceRepository::createConnection(const QString& connectionName) c
 
 // -------- generators --------
 
-Result<QVector<Generator>> DeviceRepository::getGeneratorList() const
+Etrek::Specification::Result<QVector<Generator>> DeviceRepository::getGeneratorList() const
 {
     QVector<Generator> generators;
     const QString connectionName = "dev_conn_gen_list_" + QString::number(QRandomGenerator::global()->generate());
@@ -49,7 +49,7 @@ Result<QVector<Generator>> DeviceRepository::getGeneratorList() const
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG)
                 .arg(db.lastError().text());
             logger->LogError(err);
-            return Result<QVector<Generator>>::Failure(err);
+            return Etrek::Specification::Result<QVector<Generator>>::Failure(err);
         }
 
         // Query: load all Generator fields
@@ -81,7 +81,7 @@ Result<QVector<Generator>> DeviceRepository::getGeneratorList() const
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG)
                 .arg(query.lastError().text());
             logger->LogError(err);
-            return Result<QVector<Generator>>::Failure(err);
+            return Etrek::Specification::Result<QVector<Generator>>::Failure(err);
         }
 
         // Iterate query results
@@ -114,10 +114,10 @@ Result<QVector<Generator>> DeviceRepository::getGeneratorList() const
     } // <--- Scoped connection ends here, db will be destroyed
 
     QSqlDatabase::removeDatabase(connectionName);
-    return Result<QVector<Generator>>::Success(generators);
+    return Etrek::Specification::Result<QVector<Generator>>::Success(generators);
 }
 
-Result<Generator> DeviceRepository::getGeneratorById(int id) const
+Etrek::Specification::Result<Generator> DeviceRepository::getGeneratorById(int id) const
 {
     const QString connectionName = QString("dev_conn_gen_%1").arg(id);
     QSqlDatabase db = createConnection(connectionName);
@@ -125,7 +125,7 @@ Result<Generator> DeviceRepository::getGeneratorById(int id) const
         const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG)
             .arg(db.lastError().text());
         logger->LogError(err);
-        return Result<Generator>::Failure(err);
+        return Etrek::Specification::Result<Generator>::Failure(err);
     }
 
     QSqlQuery query(db);
@@ -160,12 +160,12 @@ Result<Generator> DeviceRepository::getGeneratorById(int id) const
             .arg(query.lastError().text());
         logger->LogError(err);
         QSqlDatabase::removeDatabase(connectionName);
-        return Result<Generator>::Failure(err);
+        return Etrek::Specification::Result<Generator>::Failure(err);
     }
 
     if (!query.next()) {
         QSqlDatabase::removeDatabase(connectionName);
-        return Result<Generator>::Failure(QString("Generator with id %1 not found").arg(id));
+        return Etrek::Specification::Result<Generator>::Failure(QString("Generator with id %1 not found").arg(id));
     }
 
     Generator gen;
@@ -191,13 +191,13 @@ Result<Generator> DeviceRepository::getGeneratorById(int id) const
     gen.UpdateDate = query.value("update_date").toDateTime();
 
     QSqlDatabase::removeDatabase(connectionName);
-    return Result<Generator>::Success(gen);
+    return Etrek::Specification::Result<Generator>::Success(gen);
 }
 
-Result<Generator> DeviceRepository::updateGenerator(const Generator& generator)
+Etrek::Specification::Result<Generator> DeviceRepository::updateGenerator(const Generator& generator)
 {
     if (generator.Id == -1) {
-        return Result<Generator>::Failure("Cannot update generator: invalid Id (-1).");
+        return Etrek::Specification::Result<Generator>::Failure("Cannot update generator: invalid Id (-1).");
     }
 
     const QString connectionName = QString("dev_conn_update_gen_%1").arg(generator.Id);
@@ -207,19 +207,19 @@ Result<Generator> DeviceRepository::updateGenerator(const Generator& generator)
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG)
                 .arg(db.lastError().text());
             logger->LogError(err);
-            return Result<Generator>::Failure(err);
+            return Etrek::Specification::Result<Generator>::Failure(err);
         }
 
         // === Precondition: deactivate other active generators if needed ===
         QString preconditionError;
         if (generator.IsOutput1Active && generator.Output1 != -1) {
             if (!deactivateOtherActiveGenerators(1, generator.Id, db, preconditionError))
-                return Result<Generator>::Failure(preconditionError);
+                return Etrek::Specification::Result<Generator>::Failure(preconditionError);
         }
 
         if (generator.IsOutput2Active && generator.Output2 != -1) {
             if (!deactivateOtherActiveGenerators(2, generator.Id, db, preconditionError))
-                return Result<Generator>::Failure(preconditionError);
+                return Etrek::Specification::Result<Generator>::Failure(preconditionError);
         }
 
         // === Update the generator itself ===
@@ -267,11 +267,11 @@ Result<Generator> DeviceRepository::updateGenerator(const Generator& generator)
                 .arg(query.lastError().text());
             logger->LogError(err);
             QSqlDatabase::removeDatabase(connectionName);
-            return Result<Generator>::Failure(err);
+            return Etrek::Specification::Result<Generator>::Failure(err);
         }
     }
     QSqlDatabase::removeDatabase(connectionName);
-    return Result<Generator>::Success(generator);
+    return Etrek::Specification::Result<Generator>::Success(generator);
 }
 
 bool DeviceRepository::deactivateOtherActiveGenerators(int outputNumber, int excludeGeneratorId, QSqlDatabase& db, QString& errorMessage) const
@@ -299,7 +299,7 @@ bool DeviceRepository::deactivateOtherActiveGenerators(int outputNumber, int exc
 
 // -------- tubes --------
 
-Result<XRayTube> DeviceRepository::getXRayTube(int tubeId) const
+Etrek::Specification::Result<XRayTube> DeviceRepository::getXRayTube(int tubeId) const
 {
     const QString connectionName = "dev_conn_xray_single_" + QString::number(QRandomGenerator::global()->generate());
 
@@ -312,7 +312,7 @@ Result<XRayTube> DeviceRepository::getXRayTube(int tubeId) const
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG)
                 .arg(db.lastError().text());
             logger->LogError(err);
-            return Result<XRayTube>::Failure(err);
+            return Etrek::Specification::Result<XRayTube>::Failure(err);
         }
 
         QSqlQuery query(db);
@@ -345,12 +345,12 @@ Result<XRayTube> DeviceRepository::getXRayTube(int tubeId) const
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG)
                 .arg(query.lastError().text());
             logger->LogError(err);
-            return Result<XRayTube>::Failure(err);
+            return Etrek::Specification::Result<XRayTube>::Failure(err);
         }
 
         if (!query.next()) {
             const auto err = QString("XRayTube with id %1 not found").arg(tubeId);
-            return Result<XRayTube>::Failure(err);
+            return Etrek::Specification::Result<XRayTube>::Failure(err);
         }
 
         tube.Id = query.value("id").toInt();
@@ -377,10 +377,10 @@ Result<XRayTube> DeviceRepository::getXRayTube(int tubeId) const
     }
 
     QSqlDatabase::removeDatabase(connectionName);
-    return Result<XRayTube>::Success(tube);
+    return Etrek::Specification::Result<XRayTube>::Success(tube);
 }
 
-Result<QVector<XRayTube>> DeviceRepository::getXRayTubesList() const
+Etrek::Specification::Result<QVector<XRayTube>> DeviceRepository::getXRayTubesList() const
 {
     QVector<XRayTube> tubes;
     const QString connectionName = "dev_conn_xray_list_" + QString::number(QRandomGenerator::global()->generate());
@@ -392,7 +392,7 @@ Result<QVector<XRayTube>> DeviceRepository::getXRayTubesList() const
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG)
                 .arg(db.lastError().text());
             logger->LogError(err);
-            return Result<QVector<XRayTube>>::Failure(err);
+            return Etrek::Specification::Result<QVector<XRayTube>>::Failure(err);
         }
 
         QSqlQuery query(db);
@@ -423,7 +423,7 @@ Result<QVector<XRayTube>> DeviceRepository::getXRayTubesList() const
             QString err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG)
                 .arg(query.lastError().text());
             logger->LogError(err);
-            return Result<QVector<XRayTube>>::Failure(err);
+            return Etrek::Specification::Result<QVector<XRayTube>>::Failure(err);
         }
 
         while (query.next()) {
@@ -456,10 +456,10 @@ Result<QVector<XRayTube>> DeviceRepository::getXRayTubesList() const
     } // Scoped connection ends here
 
     QSqlDatabase::removeDatabase(connectionName);
-    return Result<QVector<XRayTube>>::Success(tubes);
+    return Etrek::Specification::Result<QVector<XRayTube>>::Success(tubes);
 }
 
-Result<XRayTube> DeviceRepository::updateXRayTube(const XRayTube& tube)
+Etrek::Specification::Result<XRayTube> DeviceRepository::updateXRayTube(const XRayTube& tube)
 {
     const QString connectionName = "dev_conn_update_xray_" + QString::number(QRandomGenerator::global()->generate());
 
@@ -469,7 +469,7 @@ Result<XRayTube> DeviceRepository::updateXRayTube(const XRayTube& tube)
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG)
                 .arg(db.lastError().text());
             logger->LogError(err);
-            return Result<XRayTube>::Failure(err);
+            return Etrek::Specification::Result<XRayTube>::Failure(err);
         }
 
         QSqlQuery query(db);
@@ -525,7 +525,7 @@ Result<XRayTube> DeviceRepository::updateXRayTube(const XRayTube& tube)
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG)
                 .arg(query.lastError().text());
             logger->LogError(err);
-            return Result<XRayTube>::Failure(err);
+            return Etrek::Specification::Result<XRayTube>::Failure(err);
         }
     } // db destroyed here
 
@@ -535,7 +535,7 @@ Result<XRayTube> DeviceRepository::updateXRayTube(const XRayTube& tube)
 
 // -------- detector --------
 
-Result<QVector<Detector>> DeviceRepository::getDetectorList() const
+Etrek::Specification::Result<QVector<Detector>> DeviceRepository::getDetectorList() const
 {
     QVector<Detector> detectors;
 
@@ -547,7 +547,7 @@ Result<QVector<Detector>> DeviceRepository::getDetectorList() const
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG)
                 .arg(db.lastError().text());
             logger->LogError(err);
-            return Result<QVector<Detector>>::Failure(err);
+            return Etrek::Specification::Result<QVector<Detector>>::Failure(err);
         }
 
         QSqlQuery query(db);
@@ -582,7 +582,7 @@ Result<QVector<Detector>> DeviceRepository::getDetectorList() const
                 .arg(query.lastError().text());
             logger->LogError(err);
             QSqlDatabase::removeDatabase(connectionName);
-            return Result<QVector<Etrek::Device::Data::Entity::Detector>>::Failure(err);
+            return Etrek::Specification::Result<QVector<Etrek::Device::Data::Entity::Detector>>::Failure(err);
         }
 
         while (query.next()) {
@@ -617,10 +617,10 @@ Result<QVector<Detector>> DeviceRepository::getDetectorList() const
     }
     
     QSqlDatabase::removeDatabase(connectionName);
-    return Result<QVector<Detector>>::Success(detectors);
+    return Etrek::Specification::Result<QVector<Detector>>::Success(detectors);
 }
 
-Result<Detector> DeviceRepository::getDetectorById(int detectorId) const
+Etrek::Specification::Result<Detector> DeviceRepository::getDetectorById(int detectorId) const
 {
     const QString connectionName = "detector_by_id_" + QString::number(QRandomGenerator::global()->generate());
     Detector d;
@@ -633,7 +633,7 @@ Result<Detector> DeviceRepository::getDetectorById(int detectorId) const
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG)
                 .arg(db.lastError().text());
             logger->LogError(err);
-            return Result<Detector>::Failure(err);
+            return Etrek::Specification::Result<Detector>::Failure(err);
         }
 
         QSqlQuery query(db);
@@ -673,7 +673,7 @@ Result<Detector> DeviceRepository::getDetectorById(int detectorId) const
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG)
                 .arg(query.lastError().text());
             logger->LogError(err);
-            return Result<Etrek::Device::Data::Entity::Detector>::Failure(err);
+            return Etrek::Specification::Result<Etrek::Device::Data::Entity::Detector>::Failure(err);
         }
 
         if (query.next()) {
@@ -700,15 +700,15 @@ Result<Detector> DeviceRepository::getDetectorById(int detectorId) const
             d.CreateDate = query.value("create_date").toDateTime();
             d.UpdateDate = query.value("update_date").toDateTime();
 
-            return Result<Detector>::Success(d);
+            return Etrek::Specification::Result<Detector>::Success(d);
         }
     } // <- db goes out of scope here
 
     QSqlDatabase::removeDatabase(connectionName);
-    return Result<Detector>::Failure("Detector not found");
+    return Etrek::Specification::Result<Detector>::Failure("Detector not found");
 }
 
-Result<Detector> DeviceRepository::updateDetector(const Detector& detector)
+Etrek::Specification::Result<Detector> DeviceRepository::updateDetector(const Detector& detector)
 {
     const QString cx = "update_detector_" + QString::number(QRandomGenerator::global()->generate());
     {
@@ -716,7 +716,7 @@ Result<Detector> DeviceRepository::updateDetector(const Detector& detector)
         if (!db.open()) {
             auto err = QString("Failed to open database: %1").arg(db.lastError().text());
             logger->LogError(err);
-            return Result<Detector>::Failure(err);
+            return Etrek::Specification::Result<Detector>::Failure(err);
         }
 
         // === Update the detector itself ===
@@ -775,18 +775,18 @@ Result<Detector> DeviceRepository::updateDetector(const Detector& detector)
         if (!query.exec()) {
             auto err = QString("Failed to update detector: %1").arg(query.lastError().text());
             logger->LogError(err);
-            return Result<Detector>::Failure(err);
+            return Etrek::Specification::Result<Detector>::Failure(err);
         }
     } // db goes out of scope
 
     QSqlDatabase::removeDatabase(cx);
-    return Result<Detector>::Success(detector);
+    return Etrek::Specification::Result<Detector>::Success(detector);
 }
 
 
 // -------------------- Institutions --------------------
 
-Result<QVector<Institution>> DeviceRepository::getInstitutionList() const
+Etrek::Specification::Result<QVector<Institution>> DeviceRepository::getInstitutionList() const
 {
     QVector<Institution> vec;
     const QString cx = "inst_list_" + QString::number(QRandomGenerator::global()->generate());
@@ -795,7 +795,7 @@ Result<QVector<Institution>> DeviceRepository::getInstitutionList() const
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<QVector<Institution>>::Failure(err);
+            return Etrek::Specification::Result<QVector<Institution>>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -809,7 +809,7 @@ Result<QVector<Institution>> DeviceRepository::getInstitutionList() const
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<QVector<Institution>>::Failure(err);
+            return Etrek::Specification::Result<QVector<Institution>>::Failure(err);
         }
 
         while (q.next()) {
@@ -826,10 +826,10 @@ Result<QVector<Institution>> DeviceRepository::getInstitutionList() const
         }
     }
     QSqlDatabase::removeDatabase(cx);
-    return Result<QVector<Institution>>::Success(vec);
+    return Etrek::Specification::Result<QVector<Institution>>::Success(vec);
 }
 
-Result<Institution> DeviceRepository::getInstitutionById(int id) const
+Etrek::Specification::Result<Institution> DeviceRepository::getInstitutionById(int id) const
 {
     const QString cx = "inst_by_id_" + QString::number(id);
     {
@@ -837,7 +837,7 @@ Result<Institution> DeviceRepository::getInstitutionById(int id) const
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<Institution>::Failure(err);
+            return Etrek::Specification::Result<Institution>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -851,11 +851,11 @@ Result<Institution> DeviceRepository::getInstitutionById(int id) const
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<Institution>::Failure(err);
+            return Etrek::Specification::Result<Institution>::Failure(err);
         }
 
         if (!q.next()) {
-            return Result<Institution>::Failure(QString("Institution with id %1 not found").arg(id));
+            return Etrek::Specification::Result<Institution>::Failure(QString("Institution with id %1 not found").arg(id));
         }
 
         Institution inst;
@@ -869,11 +869,11 @@ Result<Institution> DeviceRepository::getInstitutionById(int id) const
         inst.IsActive = q.value("is_active").toBool();
 
         QSqlDatabase::removeDatabase(cx);
-        return Result<Institution>::Success(inst);
+        return Etrek::Specification::Result<Institution>::Success(inst);
     }
 }
 
-Result<Institution> DeviceRepository::createInstitution(const Institution& inst)
+Etrek::Specification::Result<Institution> DeviceRepository::createInstitution(const Institution& inst)
 {
     const QString cx = "inst_create_" + QString::number(QRandomGenerator::global()->generate());
     int newId = -1;
@@ -882,7 +882,7 @@ Result<Institution> DeviceRepository::createInstitution(const Institution& inst)
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<Institution>::Failure(err);
+            return Etrek::Specification::Result<Institution>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -903,7 +903,7 @@ Result<Institution> DeviceRepository::createInstitution(const Institution& inst)
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<Institution>::Failure(err);
+            return Etrek::Specification::Result<Institution>::Failure(err);
         }
         newId = q.lastInsertId().toInt();
     }
@@ -911,9 +911,9 @@ Result<Institution> DeviceRepository::createInstitution(const Institution& inst)
     return getInstitutionById(newId);
 }
 
-Result<Institution> DeviceRepository::updateInstitution(const Institution& inst)
+Etrek::Specification::Result<Institution> DeviceRepository::updateInstitution(const Institution& inst)
 {
-    if (inst.Id <= 0) return Result<Institution>::Failure("Invalid institution Id.");
+    if (inst.Id <= 0) return Etrek::Specification::Result<Institution>::Failure("Invalid institution Id.");
 
     const QString cx = "inst_update_" + QString::number(inst.Id);
     {
@@ -921,7 +921,7 @@ Result<Institution> DeviceRepository::updateInstitution(const Institution& inst)
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<Institution>::Failure(err);
+            return Etrek::Specification::Result<Institution>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -949,14 +949,14 @@ Result<Institution> DeviceRepository::updateInstitution(const Institution& inst)
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<Institution>::Failure(err);
+            return Etrek::Specification::Result<Institution>::Failure(err);
         }
     }
     QSqlDatabase::removeDatabase(cx);
     return getInstitutionById(inst.Id);
 }
 
-Result<bool> DeviceRepository::deleteInstitution(int id)
+Etrek::Specification::Result<bool> DeviceRepository::deleteInstitution(int id)
 {
     const QString cx = "inst_delete_" + QString::number(id);
     {
@@ -964,7 +964,7 @@ Result<bool> DeviceRepository::deleteInstitution(int id)
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -974,14 +974,14 @@ Result<bool> DeviceRepository::deleteInstitution(int id)
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
     }
     QSqlDatabase::removeDatabase(cx);
-    return Result<bool>::Success(true);
+    return Etrek::Specification::Result<bool>::Success(true);
 }
 
-Result<bool> DeviceRepository::deactivateInstitution(int id)
+Etrek::Specification::Result<bool> DeviceRepository::deactivateInstitution(int id)
 {
     const QString cx = "inst_deactivate_" + QString::number(id);
     {
@@ -989,7 +989,7 @@ Result<bool> DeviceRepository::deactivateInstitution(int id)
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -999,17 +999,17 @@ Result<bool> DeviceRepository::deactivateInstitution(int id)
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
     }
     QSqlDatabase::removeDatabase(cx);
-    return Result<bool>::Success(true);
+    return Etrek::Specification::Result<bool>::Success(true);
 }
 
 
 // -------------------- General Equipment --------------------
 
-Result<QVector<GeneralEquipment>> DeviceRepository::getGeneralEquipmentList() const
+Etrek::Specification::Result<QVector<GeneralEquipment>> DeviceRepository::getGeneralEquipmentList() const
 {
     QVector<GeneralEquipment> vec;
     const QString cx = "ge_list_" + QString::number(QRandomGenerator::global()->generate());
@@ -1018,7 +1018,7 @@ Result<QVector<GeneralEquipment>> DeviceRepository::getGeneralEquipmentList() co
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<QVector<GeneralEquipment>>::Failure(err);
+            return Etrek::Specification::Result<QVector<GeneralEquipment>>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -1052,7 +1052,7 @@ Result<QVector<GeneralEquipment>> DeviceRepository::getGeneralEquipmentList() co
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<QVector<GeneralEquipment>>::Failure(err);
+            return Etrek::Specification::Result<QVector<GeneralEquipment>>::Failure(err);
         }
 
         while (q.next()) {
@@ -1085,10 +1085,10 @@ Result<QVector<GeneralEquipment>> DeviceRepository::getGeneralEquipmentList() co
         }
     }
     QSqlDatabase::removeDatabase(cx);
-    return Result<QVector<GeneralEquipment>>::Success(vec);
+    return Etrek::Specification::Result<QVector<GeneralEquipment>>::Success(vec);
 }
 
-Result<GeneralEquipment> DeviceRepository::getGeneralEquipmentById(int id) const
+Etrek::Specification::Result<GeneralEquipment> DeviceRepository::getGeneralEquipmentById(int id) const
 {
     const QString cx = "ge_by_id_" + QString::number(id);
     {
@@ -1096,7 +1096,7 @@ Result<GeneralEquipment> DeviceRepository::getGeneralEquipmentById(int id) const
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<GeneralEquipment>::Failure(err);
+            return Etrek::Specification::Result<GeneralEquipment>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -1132,11 +1132,11 @@ Result<GeneralEquipment> DeviceRepository::getGeneralEquipmentById(int id) const
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<GeneralEquipment>::Failure(err);
+            return Etrek::Specification::Result<GeneralEquipment>::Failure(err);
         }
 
         if (!q.next()) {
-            return Result<GeneralEquipment>::Failure(QString("GeneralEquipment with id %1 not found").arg(id));
+            return Etrek::Specification::Result<GeneralEquipment>::Failure(QString("GeneralEquipment with id %1 not found").arg(id));
         }
 
         GeneralEquipment ge;
@@ -1164,11 +1164,11 @@ Result<GeneralEquipment> DeviceRepository::getGeneralEquipmentById(int id) const
         ge.Institution.IsActive = q.value("inst_is_active").toBool();
 
         QSqlDatabase::removeDatabase(cx);
-        return Result<GeneralEquipment>::Success(ge);
+        return Etrek::Specification::Result<GeneralEquipment>::Success(ge);
     }
 }
 
-Result<GeneralEquipment> DeviceRepository::createGeneralEquipment(const GeneralEquipment& ge)
+Etrek::Specification::Result<GeneralEquipment> DeviceRepository::createGeneralEquipment(const GeneralEquipment& ge)
 {
     const QString cx = "ge_create_" + QString::number(QRandomGenerator::global()->generate());
     int newId = -1;
@@ -1177,7 +1177,7 @@ Result<GeneralEquipment> DeviceRepository::createGeneralEquipment(const GeneralE
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<GeneralEquipment>::Failure(err);
+            return Etrek::Specification::Result<GeneralEquipment>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -1213,7 +1213,7 @@ Result<GeneralEquipment> DeviceRepository::createGeneralEquipment(const GeneralE
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<GeneralEquipment>::Failure(err);
+            return Etrek::Specification::Result<GeneralEquipment>::Failure(err);
         }
         newId = q.lastInsertId().toInt();
     }
@@ -1221,9 +1221,9 @@ Result<GeneralEquipment> DeviceRepository::createGeneralEquipment(const GeneralE
     return getGeneralEquipmentById(newId);
 }
 
-Result<GeneralEquipment> DeviceRepository::updateGeneralEquipment(const GeneralEquipment& ge)
+Etrek::Specification::Result<GeneralEquipment> DeviceRepository::updateGeneralEquipment(const GeneralEquipment& ge)
 {
-    if (ge.Id <= 0) return Result<GeneralEquipment>::Failure("Invalid GeneralEquipment Id.");
+    if (ge.Id <= 0) return Etrek::Specification::Result<GeneralEquipment>::Failure("Invalid GeneralEquipment Id.");
 
     const QString cx = "ge_update_" + QString::number(ge.Id);
     {
@@ -1231,7 +1231,7 @@ Result<GeneralEquipment> DeviceRepository::updateGeneralEquipment(const GeneralE
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<GeneralEquipment>::Failure(err);
+            return Etrek::Specification::Result<GeneralEquipment>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -1274,14 +1274,14 @@ Result<GeneralEquipment> DeviceRepository::updateGeneralEquipment(const GeneralE
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<GeneralEquipment>::Failure(err);
+            return Etrek::Specification::Result<GeneralEquipment>::Failure(err);
         }
     }
     QSqlDatabase::removeDatabase(cx);
     return getGeneralEquipmentById(ge.Id);
 }
 
-Result<bool> DeviceRepository::deleteGeneralEquipment(int id)
+Etrek::Specification::Result<bool> DeviceRepository::deleteGeneralEquipment(int id)
 {
     const QString cx = "ge_delete_" + QString::number(id);
     {
@@ -1289,7 +1289,7 @@ Result<bool> DeviceRepository::deleteGeneralEquipment(int id)
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -1299,14 +1299,14 @@ Result<bool> DeviceRepository::deleteGeneralEquipment(int id)
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
     }
     QSqlDatabase::removeDatabase(cx);
-    return Result<bool>::Success(true);
+    return Etrek::Specification::Result<bool>::Success(true);
 }
 
-Result<bool> DeviceRepository::deactivateGeneralEquipment(int id)
+Etrek::Specification::Result<bool> DeviceRepository::deactivateGeneralEquipment(int id)
 {
     const QString cx = "ge_deactivate_" + QString::number(id);
     {
@@ -1314,7 +1314,7 @@ Result<bool> DeviceRepository::deactivateGeneralEquipment(int id)
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -1324,14 +1324,14 @@ Result<bool> DeviceRepository::deactivateGeneralEquipment(int id)
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
     }
     QSqlDatabase::removeDatabase(cx);
-    return Result<bool>::Success(true);
+    return Etrek::Specification::Result<bool>::Success(true);
 }
 
-Result<EnvironmentSetting> DeviceRepository::getEnvironmentSettings() const
+Etrek::Specification::Result<EnvironmentSetting> DeviceRepository::getEnvironmentSettings() const
 {
     const QString cx = "env_settings_get_" + QString::number(QRandomGenerator::global()->generate());
     {
@@ -1339,7 +1339,7 @@ Result<EnvironmentSetting> DeviceRepository::getEnvironmentSettings() const
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<EnvironmentSetting>::Failure(err);
+            return Etrek::Specification::Result<EnvironmentSetting>::Failure(err);
         }
 
         // Try to read the single row
@@ -1364,7 +1364,7 @@ Result<EnvironmentSetting> DeviceRepository::getEnvironmentSettings() const
         if (!q.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
             logger->LogError(err);
-            return Result<EnvironmentSetting>::Failure(err);
+            return Etrek::Specification::Result<EnvironmentSetting>::Failure(err);
         }
 
         if (q.next()) {
@@ -1383,7 +1383,7 @@ Result<EnvironmentSetting> DeviceRepository::getEnvironmentSettings() const
             s.UpdateDate = q.value("update_date").toDateTime();
 
             QSqlDatabase::removeDatabase(cx);
-            return Result<EnvironmentSetting>::Success(s);
+            return Etrek::Specification::Result<EnvironmentSetting>::Success(s);
         }
 
         // If table is empty, create a default row (optional convenience)
@@ -1412,7 +1412,7 @@ Result<EnvironmentSetting> DeviceRepository::getEnvironmentSettings() const
         if (!ins.exec()) {
             const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(ins.lastError().text());
             logger->LogError(err);
-            return Result<EnvironmentSetting>::Failure(err);
+            return Etrek::Specification::Result<EnvironmentSetting>::Failure(err);
         }
     }
     QSqlDatabase::removeDatabase(cx);
@@ -1420,7 +1420,7 @@ Result<EnvironmentSetting> DeviceRepository::getEnvironmentSettings() const
     return getEnvironmentSettings();
 }
 
-Result<EnvironmentSetting> DeviceRepository::updateEnvironmentSettings(const EnvironmentSetting& s)
+Etrek::Specification::Result<EnvironmentSetting> DeviceRepository::updateEnvironmentSettings(const EnvironmentSetting& s)
 {
     // Always keep a single row. Default to id=1 if not provided.
     const int targetId = (s.Id > 0) ? s.Id : 1;
@@ -1431,7 +1431,7 @@ Result<EnvironmentSetting> DeviceRepository::updateEnvironmentSettings(const Env
         if (!db.open()) {
             const auto err = translator->getErrorMessage(FAILED_TO_OPEN_DB_MSG).arg(db.lastError().text());
             logger->LogError(err);
-            return Result<EnvironmentSetting>::Failure(err);
+            return Etrek::Specification::Result<EnvironmentSetting>::Failure(err);
         }
 
         // First try UPDATE
@@ -1466,7 +1466,7 @@ Result<EnvironmentSetting> DeviceRepository::updateEnvironmentSettings(const Env
             if (!q.exec()) {
                 const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(q.lastError().text());
                 logger->LogError(err);
-                return Result<EnvironmentSetting>::Failure(err);
+                return Etrek::Specification::Result<EnvironmentSetting>::Failure(err);
             }
 
             if (q.numRowsAffected() == 0) {
@@ -1499,7 +1499,7 @@ Result<EnvironmentSetting> DeviceRepository::updateEnvironmentSettings(const Env
                 if (!qi.exec()) {
                     const auto err = translator->getCriticalMessage(QUERY_FAILED_ERROR_MSG).arg(qi.lastError().text());
                     logger->LogError(err);
-                    return Result<EnvironmentSetting>::Failure(err);
+                    return Etrek::Specification::Result<EnvironmentSetting>::Failure(err);
                 }
             }
         }

--- a/Device/Repository/DeviceRepository.h
+++ b/Device/Repository/DeviceRepository.h
@@ -30,6 +30,8 @@ using namespace Etrek::Core::Log;
 
 namespace Etrek::Device::Repository
 {
+    using Etrek::Specification::Result;
+
     class DeviceRepository
     {
     public:

--- a/Dicom/Repository/ImageCommentRepository.cpp
+++ b/Dicom/Repository/ImageCommentRepository.cpp
@@ -162,7 +162,7 @@ QVector<ImageComment> ImageCommentRepository::getAllComments() const
     return out;
 }
 
-Result<ImageComment> ImageCommentRepository::addComment(const ImageComment& comment) const
+Etrek::Specification::Result<ImageComment> ImageCommentRepository::addComment(const ImageComment& comment) const
 {
     const QString cx = "comments_add_" + QString::number(QRandomGenerator::global()->generate());
     ImageComment inserted = comment;
@@ -172,12 +172,12 @@ Result<ImageComment> ImageCommentRepository::addComment(const ImageComment& comm
         if (!db.open()) {
             const auto err = errOpen(db, translator);
             logger->LogError(err);
-            return Result<ImageComment>::Failure(err);
+            return Etrek::Specification::Result<ImageComment>::Failure(err);
         }
 
         if (comment.Heading.trimmed().isEmpty() && comment.Comment.trimmed().isEmpty()) {
             const auto err = QStringLiteral("Either Heading or Comment must be provided.");
-            return Result<ImageComment>::Failure(err);
+            return Etrek::Specification::Result<ImageComment>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -193,7 +193,7 @@ Result<ImageComment> ImageCommentRepository::addComment(const ImageComment& comm
         if (!q.exec()) {
             const auto err = errExec(q, translator);
             logger->LogError(err);
-            return Result<ImageComment>::Failure(err);
+            return Etrek::Specification::Result<ImageComment>::Failure(err);
         }
 
         const QVariant newId = q.lastInsertId();
@@ -203,13 +203,13 @@ Result<ImageComment> ImageCommentRepository::addComment(const ImageComment& comm
     }
 
     QSqlDatabase::removeDatabase(cx);
-    return Result<ImageComment>::Success(inserted, "Inserted");
+    return Etrek::Specification::Result<ImageComment>::Success(inserted, "Inserted");
 }
 
-Result<ImageComment> ImageCommentRepository::updateComment(const ImageComment& comment) const
+Etrek::Specification::Result<ImageComment> ImageCommentRepository::updateComment(const ImageComment& comment) const
 {
     if (comment.Id <= 0) {
-        return Result<ImageComment>::Failure("Invalid comment id.");
+        return Etrek::Specification::Result<ImageComment>::Failure("Invalid comment id.");
     }
 
     const QString cx = "comments_update_" + QString::number(QRandomGenerator::global()->generate());
@@ -219,7 +219,7 @@ Result<ImageComment> ImageCommentRepository::updateComment(const ImageComment& c
         if (!db.open()) {
             const auto err = errOpen(db, translator);
             logger->LogError(err);
-            return Result<ImageComment>::Failure(err);
+            return Etrek::Specification::Result<ImageComment>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -239,22 +239,22 @@ Result<ImageComment> ImageCommentRepository::updateComment(const ImageComment& c
         if (!q.exec()) {
             const auto err = errExec(q, translator);
             logger->LogError(err);
-            return Result<ImageComment>::Failure(err);
+            return Etrek::Specification::Result<ImageComment>::Failure(err);
         }
 
         if (q.numRowsAffected() == 0) {
-            return Result<ImageComment>::Failure("No rows updated (comment not found?).");
+            return Etrek::Specification::Result<ImageComment>::Failure("No rows updated (comment not found?).");
         }
     }
 
     QSqlDatabase::removeDatabase(cx);
-    return Result<ImageComment>::Success(comment, "Updated");
+    return Etrek::Specification::Result<ImageComment>::Success(comment, "Updated");
 }
 
-Result<ImageComment> ImageCommentRepository::removeComment(const ImageComment& comment) const
+Etrek::Specification::Result<ImageComment> ImageCommentRepository::removeComment(const ImageComment& comment) const
 {
     if (comment.Id <= 0) {
-        return Result<ImageComment>::Failure("Invalid comment id.");
+        return Etrek::Specification::Result<ImageComment>::Failure("Invalid comment id.");
     }
 
     const QString cx = "comments_delete_" + QString::number(QRandomGenerator::global()->generate());
@@ -264,7 +264,7 @@ Result<ImageComment> ImageCommentRepository::removeComment(const ImageComment& c
         if (!db.open()) {
             const auto err = errOpen(db, translator);
             logger->LogError(err);
-            return Result<ImageComment>::Failure(err);
+            return Etrek::Specification::Result<ImageComment>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -277,16 +277,16 @@ Result<ImageComment> ImageCommentRepository::removeComment(const ImageComment& c
         if (!q.exec()) {
             const auto err = errExec(q, translator);
             logger->LogError(err);
-            return Result<ImageComment>::Failure(err);
+            return Etrek::Specification::Result<ImageComment>::Failure(err);
         }
 
         if (q.numRowsAffected() == 0) {
-            return Result<ImageComment>::Failure("No rows deleted (comment not found?).");
+            return Etrek::Specification::Result<ImageComment>::Failure("No rows deleted (comment not found?).");
         }
     }
 
     QSqlDatabase::removeDatabase(cx);
-    return Result<ImageComment>::Success(comment, "Deleted");
+    return Etrek::Specification::Result<ImageComment>::Success(comment, "Deleted");
 }
 
 ImageCommentRepository::~ImageCommentRepository() = default;

--- a/Dicom/Repository/ImageCommentRepository.h
+++ b/Dicom/Repository/ImageCommentRepository.h
@@ -29,9 +29,9 @@ public:
 	QVector<ImageComment> getAcceptedComments() const;
 	QVector<ImageComment> getRejectComments() const;
 	QVector<ImageComment> getAllComments() const;
-	Result<ImageComment> addComment(const ImageComment& comment) const;
-	Result<ImageComment> removeComment(const ImageComment& comment) const;
-	Result<ImageComment> updateComment(const ImageComment& comment) const;
+	Etrek::Specification::Result<ImageComment> addComment(const ImageComment& comment) const;
+	Etrek::Specification::Result<ImageComment> removeComment(const ImageComment& comment) const;
+	Etrek::Specification::Result<ImageComment> updateComment(const ImageComment& comment) const;
 
 	~ImageCommentRepository();
 

--- a/Executable/main.cpp
+++ b/Executable/main.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
     });
 
     QStringList arguments = QCoreApplication::arguments();
-    LaunchMode mode = ParseLaunchMode(arguments);
+    const Etrek::Specification::LaunchMode mode = Etrek::Specification::ParseLaunchMode(arguments);
 
     Etrek::Application::Service::ApplicationService applicationService(&a);
     try {

--- a/Pacs/Repository/PacsNodeRepository.cpp
+++ b/Pacs/Repository/PacsNodeRepository.cpp
@@ -100,29 +100,29 @@ QVector<PacsNode> PacsNodeRepository::getPacsNodes() const
     return out;
 }
 
-Result<PacsNode> PacsNodeRepository::addPacsNode(const PacsNode& node) const
+Etrek::Specification::Result<PacsNode> PacsNodeRepository::addPacsNode(const PacsNode& node) const
 {
     const QString cx = "pacs_nodes_add_" + QString::number(QRandomGenerator::global()->generate());
     PacsNode inserted = node;
 
     // Basic validations (tune as needed)
     if (node.HostName.trimmed().isEmpty())
-        return Result<PacsNode>::Failure("HostName is required.");
+        return Etrek::Specification::Result<PacsNode>::Failure("HostName is required.");
     if (node.HostIp.trimmed().isEmpty())
-        return Result<PacsNode>::Failure("HostIp is required.");
+        return Etrek::Specification::Result<PacsNode>::Failure("HostIp is required.");
     if (node.Port <= 0 || node.Port > 65535)
-        return Result<PacsNode>::Failure("Port must be between 1 and 65535.");
+        return Etrek::Specification::Result<PacsNode>::Failure("Port must be between 1 and 65535.");
     if (node.CalledAet.trimmed().isEmpty())
-        return Result<PacsNode>::Failure("CalledAET is required.");
+        return Etrek::Specification::Result<PacsNode>::Failure("CalledAET is required.");
     if (node.CallingAet.trimmed().isEmpty())
-        return Result<PacsNode>::Failure("CallingAET is required.");
+        return Etrek::Specification::Result<PacsNode>::Failure("CallingAET is required.");
 
     {
         QSqlDatabase db = createConnection(cx);
         if (!db.open()) {
             const auto err = errOpen(db, translator);
             logger->LogError(err);
-            return Result<PacsNode>::Failure(err);
+            return Etrek::Specification::Result<PacsNode>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -144,7 +144,7 @@ Result<PacsNode> PacsNodeRepository::addPacsNode(const PacsNode& node) const
         if (!q.exec()) {
             const auto err = errExec(q, translator);
             logger->LogError(err);
-            return Result<PacsNode>::Failure(err);
+            return Etrek::Specification::Result<PacsNode>::Failure(err);
         }
 
         const QVariant newId = q.lastInsertId();
@@ -152,24 +152,24 @@ Result<PacsNode> PacsNodeRepository::addPacsNode(const PacsNode& node) const
     }
 
     QSqlDatabase::removeDatabase(cx);
-    return Result<PacsNode>::Success(inserted, "Inserted");
+    return Etrek::Specification::Result<PacsNode>::Success(inserted, "Inserted");
 }
 
-Result<PacsNode> PacsNodeRepository::updatePacsNode(const PacsNode& node) const
+Etrek::Specification::Result<PacsNode> PacsNodeRepository::updatePacsNode(const PacsNode& node) const
 {
     if (node.Id <= 0)
-        return Result<PacsNode>::Failure("Invalid node Id.");
+        return Etrek::Specification::Result<PacsNode>::Failure("Invalid node Id.");
 
     if (node.HostName.trimmed().isEmpty())
-        return Result<PacsNode>::Failure("HostName is required.");
+        return Etrek::Specification::Result<PacsNode>::Failure("HostName is required.");
     if (node.HostIp.trimmed().isEmpty())
-        return Result<PacsNode>::Failure("HostIp is required.");
+        return Etrek::Specification::Result<PacsNode>::Failure("HostIp is required.");
     if (node.Port <= 0 || node.Port > 65535)
-        return Result<PacsNode>::Failure("Port must be between 1 and 65535.");
+        return Etrek::Specification::Result<PacsNode>::Failure("Port must be between 1 and 65535.");
     if (node.CalledAet.trimmed().isEmpty())
-        return Result<PacsNode>::Failure("CalledAET is required.");
+        return Etrek::Specification::Result<PacsNode>::Failure("CalledAET is required.");
     if (node.CallingAet.trimmed().isEmpty())
-        return Result<PacsNode>::Failure("CallingAET is required.");
+        return Etrek::Specification::Result<PacsNode>::Failure("CallingAET is required.");
 
     const QString cx = "pacs_nodes_upd_" + QString::number(QRandomGenerator::global()->generate());
 
@@ -178,7 +178,7 @@ Result<PacsNode> PacsNodeRepository::updatePacsNode(const PacsNode& node) const
         if (!db.open()) {
             const auto err = errOpen(db, translator);
             logger->LogError(err);
-            return Result<PacsNode>::Failure(err);
+            return Etrek::Specification::Result<PacsNode>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -204,22 +204,22 @@ Result<PacsNode> PacsNodeRepository::updatePacsNode(const PacsNode& node) const
         if (!q.exec()) {
             const auto err = errExec(q, translator);
             logger->LogError(err);
-            return Result<PacsNode>::Failure(err);
+            return Etrek::Specification::Result<PacsNode>::Failure(err);
         }
 
         if (q.numRowsAffected() == 0) {
-            return Result<PacsNode>::Failure("No rows updated (node not found?).");
+            return Etrek::Specification::Result<PacsNode>::Failure("No rows updated (node not found?).");
         }
     }
 
     QSqlDatabase::removeDatabase(cx);
-    return Result<PacsNode>::Success(node, "Updated");
+    return Etrek::Specification::Result<PacsNode>::Success(node, "Updated");
 }
 
-Result<bool> PacsNodeRepository::removePacsNode(const PacsNode& node) const
+Etrek::Specification::Result<bool> PacsNodeRepository::removePacsNode(const PacsNode& node) const
 {
     if (node.Id <= 0)
-        return Result<bool>::Failure("Invalid node Id.");
+        return Etrek::Specification::Result<bool>::Failure("Invalid node Id.");
 
     const QString cx = "pacs_nodes_del_" + QString::number(QRandomGenerator::global()->generate());
     bool deleted = false;
@@ -229,7 +229,7 @@ Result<bool> PacsNodeRepository::removePacsNode(const PacsNode& node) const
         if (!db.open()) {
             const auto err = errOpen(db, translator);
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
 
         QSqlQuery q(db);
@@ -242,15 +242,15 @@ Result<bool> PacsNodeRepository::removePacsNode(const PacsNode& node) const
         if (!q.exec()) {
             const auto err = errExec(q, translator);
             logger->LogError(err);
-            return Result<bool>::Failure(err);
+            return Etrek::Specification::Result<bool>::Failure(err);
         }
 
         deleted = (q.numRowsAffected() > 0);
         if (!deleted) {
-            return Result<bool>::Failure("No rows deleted (node not found?).");
+            return Etrek::Specification::Result<bool>::Failure("No rows deleted (node not found?).");
         }
     }
 
     QSqlDatabase::removeDatabase(cx);
-    return Result<bool>::Success(true, "Deleted");
+    return Etrek::Specification::Result<bool>::Success(true, "Deleted");
 }

--- a/Pacs/Repository/PacsNodeRepository.h
+++ b/Pacs/Repository/PacsNodeRepository.h
@@ -24,9 +24,9 @@ class PacsNodeRepository
 public:
     explicit PacsNodeRepository(std::shared_ptr<DatabaseConnectionSetting> connectionSetting);
 
-    Result<PacsNode> addPacsNode(const PacsNode& node) const;
-    Result<bool>     removePacsNode(const PacsNode& node) const;
-    Result<PacsNode> updatePacsNode(const PacsNode& node) const;
+    Etrek::Specification::Result<PacsNode> addPacsNode(const PacsNode& node) const;
+    Etrek::Specification::Result<bool>     removePacsNode(const PacsNode& node) const;
+    Etrek::Specification::Result<PacsNode> updatePacsNode(const PacsNode& node) const;
 
     QVector<PacsNode> getPacsNodes() const;
 

--- a/ScanProtocol/Repository/ScanProtocolRepository.cpp
+++ b/ScanProtocol/Repository/ScanProtocolRepository.cpp
@@ -15,6 +15,7 @@ static inline QString kRepoName() { return "ScanProtocolRepository"; }
 
 using Etrek::ScanProtocol::ScanProtocolUtil;
 using namespace Etrek::ScanProtocol::Repository;
+using Etrek::Specification::Result;
 
 // ----------------------------- Local DB helpers ------------------------------
 #include <QVariant>

--- a/ScanProtocol/Repository/ScanProtocolRepository.h
+++ b/ScanProtocol/Repository/ScanProtocolRepository.h
@@ -29,6 +29,8 @@ using namespace Etrek::ScanProtocol::Data::Entity;
 
 namespace Etrek::ScanProtocol::Repository {
 
+    using Etrek::Specification::Result;
+
     class ScanProtocolRepository
     {
     public:

--- a/Test/Core/tst_DatabaseInitializer.cpp
+++ b/Test/Core/tst_DatabaseInitializer.cpp
@@ -67,7 +67,7 @@ void DatabaseInitializerTest::testInitializeDatabase_createsDbAndTables()
     QVERIFY(QFile::exists("temp_test_script.sql"));
 
     DatabaseInitializer initializer(m_connectionSettings);
-    Result<QString> result = initializer.InitializeDatabase(std::move(customFile));
+    Etrek::Specification::Result<QString> result = initializer.InitializeDatabase(std::move(customFile));
 
     QVERIFY2(result.isSuccess, qUtf8Printable("Database initialization failed: " + result.message));
 

--- a/Test/tst_RisManager.cpp
+++ b/Test/tst_RisManager.cpp
@@ -16,33 +16,33 @@ public:
     explicit MockWorklistRepository(std::shared_ptr<DatabaseConnectionSetting> connectionSetting)
         : WorklistRepository(std::move(connectionSetting)) {}
 
-    Result<QList<WorklistProfile>> GetProfiles() const override {
+    Etrek::Specification::Result<QList<WorklistProfile>> GetProfiles() const override {
         WorklistProfile profile;
         profile.Id = 1;
         profile.Context.Id = 1;
         profile.Context.TransferSyntaxUid = "1.2.840.10008.1.2";
         profile.Context.ProfileId = 1;
-        return Result<QList<WorklistProfile>>::Success({ profile });
+        return Etrek::Specification::Result<QList<WorklistProfile>>::Success({ profile });
     }
 
-    Result<QList<DicomTag>> GetTagsByProfile(int) const override {
-        return Result<QList<DicomTag>>::Success({
+    Etrek::Specification::Result<QList<DicomTag>> GetTagsByProfile(int) const override {
+        return Etrek::Specification::Result<QList<DicomTag>>::Success({
             { -1,"Patient ID" ,"PatientID", 0x0010, 0x0020, 0, 0, true }
         });
     }
 
-    Result<WorklistEntry> GetWorklistEntryById(int) const override {
-        return Result<WorklistEntry>::Failure("Not found");
+    Etrek::Specification::Result<WorklistEntry> GetWorklistEntryById(int) const override {
+        return Etrek::Specification::Result<WorklistEntry>::Failure("Not found");
     }
 
-    Result<int> CreateWorklistEntry(const WorklistEntry& entry) override {
+    Etrek::Specification::Result<int> CreateWorklistEntry(const WorklistEntry& entry) override {
         created.append(entry);
-        return Result<int>::Success(1);
+        return Etrek::Specification::Result<int>::Success(1);
     }
 
-    Result<int> UpdateWorklistEntry(const WorklistEntry& entry) override {
+    Etrek::Specification::Result<int> UpdateWorklistEntry(const WorklistEntry& entry) override {
         updated.append(entry);
-        return Result<int>::Success(1);
+        return Etrek::Specification::Result<int>::Success(1);
     }
 
     QList<WorklistEntry> created;

--- a/Test/tst_WorklistRepository.cpp
+++ b/Test/tst_WorklistRepository.cpp
@@ -41,10 +41,10 @@ private:
     }
 
     // Helper function to get tags by profile ID
-    Result<QList<DicomTag>> getTags(int profileId) {
+    Etrek::Specification::Result<QList<DicomTag>> getTags(int profileId) {
         auto getTagsResult = manager->GetTagsByProfile(profileId);
         if (!getTagsResult.isSuccess || getTagsResult.value.isEmpty()) {
-            return Result<QList<DicomTag>>::Failure("Failed to fetch tags");
+            return Etrek::Specification::Result<QList<DicomTag>>::Failure("Failed to fetch tags");
         }
         return getTagsResult;
     }

--- a/Worklist/Connectivity/WorklistQueryService.cpp
+++ b/Worklist/Connectivity/WorklistQueryService.cpp
@@ -56,12 +56,12 @@ void WorklistQueryService::setSettings(std::shared_ptr<RisConnectionSetting> set
     setupTheConnectionParameters();
 }
 
-Result<QString> WorklistQueryService::prepareAssociation()
+Etrek::Specification::Result<QString> WorklistQueryService::prepareAssociation()
 {
      //QMutexLocker locker(&m_scuMutex);
 
     if (!m_dcmScu) {
-        return Result<QString>::Failure("DICOM SCU not initialized.");
+        return Etrek::Specification::Result<QString>::Failure("DICOM SCU not initialized.");
     }
 
     // Release any existing association to start fresh
@@ -73,14 +73,14 @@ Result<QString> WorklistQueryService::prepareAssociation()
     {
         QString message = "Failed to add C-ECHO context: " + addEcho.message;
         qDebug()<<message;
-        return Result<QString>::Failure(addEcho.message);
+        return Etrek::Specification::Result<QString>::Failure(addEcho.message);
     }
     auto addFind = addPresentationContextForOperation("C-FIND");
     if (!addFind.isSuccess)
     {
         QString message = "Failed to add C-FIND context: " + addFind.message;
         qDebug()<<message;
-        return Result<QString>::Failure(addFind.message);
+        return Etrek::Specification::Result<QString>::Failure(addFind.message);
     }
     auto initNet = initNetwork();
     if (!initNet.isSuccess)
@@ -95,22 +95,22 @@ Result<QString> WorklistQueryService::prepareAssociation()
         return echo;
 
     auto message = translator->getInfoMessage(RIS_ASSOCIATION_NEGOTIATION_SUCCEED);
-    return Result<QString>::Success(message);
+    return Etrek::Specification::Result<QString>::Success(message);
 }
 
-Result<QString> WorklistQueryService::releaseAssociation()
+Etrek::Specification::Result<QString> WorklistQueryService::releaseAssociation()
 {
     if (!m_dcmScu)
-        return Result<QString>::Failure("DICOM SCU not initialized.");
+        return Etrek::Specification::Result<QString>::Failure("DICOM SCU not initialized.");
 
     OFCondition cond = m_dcmScu->releaseAssociation();
     if (cond.bad()) {
         QString err = translator->getErrorMessage(RIS_RELEASE_CONNECTION_FAILED).arg(cond.text());
         logger->LogError(err);
-        return Result<QString>::Failure(err);
+        return Etrek::Specification::Result<QString>::Failure(err);
     }
 
-    return Result<QString>::Success(translator->getInfoMessage(RIS_RELEASE_CONNECTION_SUCCEED));
+    return Etrek::Specification::Result<QString>::Success(translator->getInfoMessage(RIS_RELEASE_CONNECTION_SUCCEED));
 }
 
 QList<WorklistEntry> WorklistQueryService::getWorklistEntries()
@@ -219,7 +219,7 @@ std::unique_ptr<DcmDataset> WorklistQueryService::createWorklistQuery(const QLis
 }
 
 
-Result<QString> WorklistQueryService::echoRis()
+Etrek::Specification::Result<QString> WorklistQueryService::echoRis()
 {
     if (!isConnected()) {
         setupTheConnectionParameters();
@@ -229,43 +229,43 @@ Result<QString> WorklistQueryService::echoRis()
     if (cond.bad()) {
         QString err = translator->getErrorMessage(RIS_C_ECHO_FAILED).arg(cond.text());
         logger->LogError(err);
-        return Result<QString>::Failure(err);
+        return Etrek::Specification::Result<QString>::Failure(err);
     }
 
     QString msg = translator->getInfoMessage(RIS_C_ECHO_SUCCEED);
-    return Result<QString>::Success(msg);
+    return Etrek::Specification::Result<QString>::Success(msg);
 }
 
-Result<QString> WorklistQueryService::initNetwork()
+Etrek::Specification::Result<QString> WorklistQueryService::initNetwork()
 {
     OFCondition cond = m_dcmScu->initNetwork();
     if (cond.bad()) {
         QString err = translator->getErrorMessage(RIS_NETWORK_INIT_FAILED).arg(cond.text());
         logger->LogError(err);
-        return Result<QString>::Failure(err);
+        return Etrek::Specification::Result<QString>::Failure(err);
     }
     QString msg = translator->getInfoMessage(RIS_NETWORK_INIT_SUCCEED);
-    return Result<QString>::Success(msg);
+    return Etrek::Specification::Result<QString>::Success(msg);
 }
 
-Result<QString> WorklistQueryService::negotiateTheAssociation()
+Etrek::Specification::Result<QString> WorklistQueryService::negotiateTheAssociation()
 {
     OFCondition cond = m_dcmScu->negotiateAssociation();
     if (cond.bad()) {
         QString error = translator->getDebugMessage(RIS_ASSOCIATION_NEGOTIATION_FAILED).arg(cond.text());
         logger->LogError(error);
-        return Result<QString>::Failure(error);
+        return Etrek::Specification::Result<QString>::Failure(error);
     }
     QString msg = translator->getInfoMessage(RIS_ASSOCIATION_NEGOTIATION_SUCCEED);
-    return Result<QString>::Success(msg);
+    return Etrek::Specification::Result<QString>::Success(msg);
 }
 
-Result<int> WorklistQueryService::addPresentationContextForOperation(const QString& operation)
+Etrek::Specification::Result<int> WorklistQueryService::addPresentationContextForOperation(const QString& operation)
 {
     if (m_presentationContext.Id == -1) {
         QString message = translator->getErrorMessage(RIS_PRESENTATION_CONTEXT_NOT_SET_MSG);
         logger->LogError(message);
-        return Result<int>::Failure(message);
+        return Etrek::Specification::Result<int>::Failure(message);
     }
 
     OFString sopClassUid;
@@ -280,7 +280,7 @@ Result<int> WorklistQueryService::addPresentationContextForOperation(const QStri
     else {
         auto message = translator->getErrorMessage(RIS_INVALID_OPERATION_SPECIFIED);
         logger->LogError(message);
-        return Result<int>::Failure(message);
+        return Etrek::Specification::Result<int>::Failure(message);
     }
 
     OFList<OFString> transferSyntaxList;
@@ -290,14 +290,14 @@ Result<int> WorklistQueryService::addPresentationContextForOperation(const QStri
     if (cond.bad()) {
         QString message = translator->getDebugMessage(RIS_ADD_PRESENTATION_CONTEXT_FAILED).arg(cond.text());
         logger->LogDebug(message);
-        return Result<int>::Failure(message);
+        return Etrek::Specification::Result<int>::Failure(message);
     }
 
     int presentationNumber = m_dcmScu->findPresentationContextID(sopClassUid, transferSyntaxUid);
     if (presentationNumber == 0)
         presentationNumber = 1; // fallback, but typically should be 1 or 3
 
-    return Result<int>::Success(presentationNumber);
+    return Etrek::Specification::Result<int>::Success(presentationNumber);
 }
 
 void WorklistQueryService::setupTheConnectionParameters()

--- a/Worklist/Connectivity/WorklistQueryService.h
+++ b/Worklist/Connectivity/WorklistQueryService.h
@@ -43,13 +43,13 @@ public:
     void setSettings(std::shared_ptr<RisConnectionSetting> settings);
 
     // Explicitly prepare the DICOM association (add contexts + negotiate)
-    Result<QString> prepareAssociation();
+    Etrek::Specification::Result<QString> prepareAssociation();
 
     // Release association explicitly
-    Result<QString> releaseAssociation();
+    Etrek::Specification::Result<QString> releaseAssociation();
 
     QList<WorklistEntry> getWorklistEntries();
-    Result<QString> echoRis();
+    Etrek::Specification::Result<QString> echoRis();
 
 signals:
     void worklistEntriesReceived(const QList<WorklistEntry>& worklistEntries);
@@ -58,11 +58,11 @@ private:
     std::unique_ptr<DcmDataset> createWorklistQuery(const QList<DicomTag>& queryTags) noexcept;
 
 
-    Result<QString> initNetwork();
-    Result<QString> negotiateTheAssociation();
+    Etrek::Specification::Result<QString> initNetwork();
+    Etrek::Specification::Result<QString> negotiateTheAssociation();
 
     // Adds a single presentation context (for echo or find)
-    Result<int> addPresentationContextForOperation(const QString& operation);
+    Etrek::Specification::Result<int> addPresentationContextForOperation(const QString& operation);
 
     void setupTheConnectionParameters();
     bool isConnected();

--- a/Worklist/Repository/WorklistFieldConfigurationRepository.cpp
+++ b/Worklist/Repository/WorklistFieldConfigurationRepository.cpp
@@ -7,8 +7,10 @@
 
 
 using namespace Etrek::Worklist::Data::Entity;
-namespace Etrek::Worklist::Repository 
+
+namespace Etrek::Worklist::Repository
 {
+    using Etrek::Specification::Result;
 
     WorklistFieldConfigurationRepository::WorklistFieldConfigurationRepository(std::shared_ptr<DatabaseConnectionSetting> connectionSetting)
         : m_connectionSetting(connectionSetting)

--- a/Worklist/Repository/WorklistFieldConfigurationRepository.h
+++ b/Worklist/Repository/WorklistFieldConfigurationRepository.h
@@ -16,6 +16,7 @@ namespace Etrek::Worklist::Repository
     using namespace Etrek::Core::Log;
     using namespace Etrek::Core::Data::Model;
     using namespace Etrek::Worklist::Data::Entity;
+    using Etrek::Specification::Result;
     class WorklistFieldConfigurationRepository
     {
     public:

--- a/Worklist/Repository/WorklistRepository.cpp
+++ b/Worklist/Repository/WorklistRepository.cpp
@@ -10,6 +10,8 @@
 
 namespace Etrek::Worklist::Repository {
 
+    using Etrek::Specification::Result;
+
     WorklistRepository::WorklistRepository(std::shared_ptr<DatabaseConnectionSetting> connectionSetting, QObject* parent)
         : QObject(parent), m_connectionSetting(connectionSetting), translator(nullptr), logger(nullptr)
     {

--- a/Worklist/Repository/WorklistRepository.h
+++ b/Worklist/Repository/WorklistRepository.h
@@ -21,6 +21,8 @@ using namespace Etrek::Core::Data::Model;
 
 namespace Etrek::Worklist::Repository {
 
+    using Etrek::Specification::Result;
+
     /**
      * @class WorklistRepository
      * @brief Provides data access and management for DICOM worklist entries, profiles, and attributes.


### PR DESCRIPTION
## Summary
- wrap the Application delegate headers and sources in the `Etrek::Application::Delegate` namespace and align their implementations
- move `LaunchMode` and `Result` into the `Etrek::Specification` namespace and update all references to the new qualifiers
- adjust services, repositories, and tests to use the standardized namespace-aware `Result` type

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1586cf57c832f8fbafae4d2fa3d4d