### PR TITLE
Simplify include path for ScanProtocolRepository.h

### DIFF
--- a/Worklist/Delegate/WorkListPageDelegate.h
+++ b/Worklist/Delegate/WorkListPageDelegate.h
@@ -9,7 +9,7 @@
 #include <QDateTime>
 #include "WorklistRepository.h"
 #include "WorkListPage.h"
-#include "../../ScanProtocol/Repository/ScanProtocolRepository.h"
+#include "ScanProtocolRepository.h"
 #include "DateTimeSpan.h"
 #include "IDelegate.h"
 #include "IPageAction.h"


### PR DESCRIPTION
Updated the `#include` directive for `ScanProtocolRepository.h` to use a relative path instead of a nested relative path. Replaced `#include "../../ScanProtocol/Repository/ScanProtocolRepository.h"` with `#include "ScanProtocolRepository.h"`. This change improves code readability and aligns with potential directory structure reorganization or updated include path configurations.