### PR TITLE
Refactor WorkListPage for flexibility and maintainability

### DIFF
--- a/View/Page/WorklistPage.cpp
+++ b/View/Page/WorklistPage.cpp
@@ -164,9 +164,9 @@ void WorkListPage::closePage()
     hide();  // or setVisible(false);
 }
 
-void WorkListPage::setProxyModel(QPointer<QStandardItemModel> proxyModel)
+void WorkListPage::setProxyModel(QAbstractItemModel* model)
 {
-   ui->tableViewWorklist->setModel(proxyModel);
+   ui->tableViewWorklist->setModel(model);
    ui->tableViewWorklist->setEditTriggers(QAbstractItemView::NoEditTriggers);
    ui->tableViewWorklist->horizontalHeader()->setStretchLastSection(true);
    ui->tableViewWorklist->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);

--- a/View/Page/WorklistPage.h
+++ b/View/Page/WorklistPage.h
@@ -3,7 +3,7 @@
 
 #include <QWidget>
 #include "IWorklistRepository.h"
-#include <QStandardItemModel.h>
+#include <QAbstractItemModel>
 #include "DateTimeSpan.h"
 
 namespace Ui {
@@ -18,7 +18,7 @@ class WorkListPage : public QWidget
 
 public:
     explicit WorkListPage(std::shared_ptr<Etrek::Worklist::Repository::IWorklistRepository> repository,QWidget *parent = nullptr);
-    void setProxyModel(QPointer<QStandardItemModel> proxyModel);
+    void setProxyModel(QAbstractItemModel* model);
     void closePage();
     ~WorkListPage();
 


### PR DESCRIPTION
Refactored `setProxyModel` to use `QAbstractItemModel*` for improved flexibility with different model types. Updated includes and method signatures accordingly.

Replaced dynamic column header generation with a fixed column structure for consistent worklist display. Added headers such as "Patient Name", "Patient ID", and "Study Name".

Enhanced row creation logic in `createRowForEntry` with a reusable lambda for consistent item styling and metadata. Added formatting for "Birth Date" and ensured all columns are populated appropriately.

Simplified `loadWorklistData` and `onEntryCreated` methods to use the fixed column structure. Removed redundant code related to dynamic `DicomTag` handling.

Performed general code cleanup to improve readability, maintainability, and consistency across the `WorkListPage` and `WorkListPageDelegate` classes.