### PR TITLE
Add functional filtering to Worklist page with default 1-year range

### DIFF
--- a/Application/Delegate/WorkListPageDelegate.cpp
+++ b/Application/Delegate/WorkListPageDelegate.cpp
@@ -13,6 +13,7 @@
 #include "LocalMwlRegistrationService.h"
 #include "IContextManager.h"
 #include "ExaminationContext.h"
+#include "WorklistFilterProxyModel.h"
 
 
 using namespace Etrek::Worklist::Repository;
@@ -37,10 +38,8 @@ namespace Etrek::Application::Delegate
         , contextManager(contextManager) {
 
         baseModel = new QStandardItemModel(this);
-        proxyModel = new QSortFilterProxyModel(this);
+        proxyModel = new WorklistFilterProxyModel(this);
         proxyModel->setSourceModel(baseModel);
-        proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
-        proxyModel->setFilterKeyColumn(-1);
 
         connect(ui, &WorkListPage::addNewPatient, this, &WorkListPageDelegate::onAddNewPatient);
         connect(ui, &WorkListPage::updatePatient, this, &WorkListPageDelegate::onUpdatePatient);
@@ -209,21 +208,38 @@ namespace Etrek::Application::Delegate
         }
     }
 
-    void WorkListPageDelegate::onFilterDateRangeChanged(const DateTimeSpan& date) {
-        //applyFilters();
+    void WorkListPageDelegate::onFilterDateRangeChanged(const DateTimeSpan& dateSpan) {
+        if (proxyModel) {
+            proxyModel->setDateRangeFilter(dateSpan.from.date(), dateSpan.to.date());
+        }
     }
 
 
     void WorkListPageDelegate::onSourceChanged(const QString& source)
     {
+        if (proxyModel) {
+            // Empty string or "All" means no source filter
+            QString filterValue = (source.isEmpty() || source.compare("All", Qt::CaseInsensitive) == 0)
+                ? QString()
+                : source;
+            proxyModel->setSourceFilter(filterValue);
+        }
     }
 
     void WorkListPageDelegate::onClearFilters() {
+        // Load all worklist data from repository
+        auto result = repository->getWorklistEntries(nullptr, nullptr);
+        if (result.isSuccess) {
+            loadWorklistData(result.value);
+        }
 
-         auto result = repository->getWorklistEntries(nullptr, nullptr);
-         if (result.isSuccess) {
-             loadWorklistData(result.value);
-         }
+        // Apply default filter: last 1 year to today, no source filter
+        if (proxyModel) {
+            QDate today = QDate::currentDate();
+            QDate oneYearAgo = today.addYears(-1);
+            proxyModel->setDateRangeFilter(oneYearAgo, today);
+            proxyModel->setSourceFilter(QString()); // Clear source filter
+        }
     }
 
     void WorkListPageDelegate::onSearchChanged() {

--- a/Application/Delegate/WorkListPageDelegate.h
+++ b/Application/Delegate/WorkListPageDelegate.h
@@ -5,7 +5,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QStandardItemModel>
-#include <QSortFilterProxyModel>
+#include "WorklistFilterProxyModel.h"
 #include <QDateTime>
 #include "WorklistRepository.h"
 #include "WorkListPage.h"
@@ -90,7 +90,7 @@ namespace Etrek::Application::Delegate {
         QList<ent::DicomTag> getDisplayTagList() const;
         QList<QStandardItem*> createRowForEntry(const ent::WorklistEntry& entry) const;
         QPointer<QStandardItemModel> baseModel;
-        QPointer<QSortFilterProxyModel> proxyModel;
+        QPointer<WorklistFilterProxyModel> proxyModel;
         std::shared_ptr<repo::WorklistRepository> repository;
         std::shared_ptr<Etrek::ScanProtocol::Repository::ScanProtocolRepository> scanRepository;
         std::shared_ptr<Etrek::Dicom::Repository::DicomRepository> dicomRepository;

--- a/Application/Delegate/WorklistFilterProxyModel.cpp
+++ b/Application/Delegate/WorklistFilterProxyModel.cpp
@@ -1,0 +1,81 @@
+#include "WorklistFilterProxyModel.h"
+#include <QDateTime>
+
+namespace Etrek::Application::Delegate {
+
+WorklistFilterProxyModel::WorklistFilterProxyModel(QObject* parent)
+    : QSortFilterProxyModel(parent)
+{
+    // Set default filter behavior
+    setFilterCaseSensitivity(Qt::CaseInsensitive);
+}
+
+void WorklistFilterProxyModel::setDateRangeFilter(const QDate& fromDate, const QDate& toDate)
+{
+    m_fromDate = fromDate;
+    m_toDate = toDate;
+    invalidateFilter();
+}
+
+void WorklistFilterProxyModel::setSourceFilter(const QString& source)
+{
+    m_sourceFilter = source.trimmed();
+    invalidateFilter();
+}
+
+void WorklistFilterProxyModel::clearFilters()
+{
+    m_fromDate = QDate();
+    m_toDate = QDate();
+    m_sourceFilter.clear();
+    invalidateFilter();
+}
+
+bool WorklistFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const
+{
+    // Get the source model
+    QAbstractItemModel* model = sourceModel();
+    if (!model)
+        return true;
+
+    // Check source filter (column 8)
+    if (!m_sourceFilter.isEmpty()) {
+        QModelIndex sourceIndex = model->index(sourceRow, SourceColumn, sourceParent);
+        QString sourceValue = model->data(sourceIndex).toString();
+
+        // Case-insensitive comparison
+        if (sourceValue.compare(m_sourceFilter, Qt::CaseInsensitive) != 0)
+            return false;
+    }
+
+    // Check date range filter (column 9 - "Created At" in format "yyyy-MM-dd HH:mm")
+    if (m_fromDate.isValid() || m_toDate.isValid()) {
+        QModelIndex dateIndex = model->index(sourceRow, CreatedAtColumn, sourceParent);
+        QString dateStr = model->data(dateIndex).toString();
+
+        // Parse the date from the "yyyy-MM-dd HH:mm" format
+        QDateTime dateTime = QDateTime::fromString(dateStr, "yyyy-MM-dd HH:mm");
+        if (!dateTime.isValid()) {
+            // Try parsing as date only
+            QDate date = QDate::fromString(dateStr.left(10), "yyyy-MM-dd");
+            if (date.isValid())
+                dateTime = QDateTime(date, QTime(0, 0));
+        }
+
+        if (dateTime.isValid()) {
+            QDate rowDate = dateTime.date();
+
+            // Check lower bound (from date)
+            if (m_fromDate.isValid() && rowDate < m_fromDate)
+                return false;
+
+            // Check upper bound (to date)
+            if (m_toDate.isValid() && rowDate > m_toDate)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace Etrek::Application::Delegate

--- a/Application/Delegate/WorklistFilterProxyModel.h
+++ b/Application/Delegate/WorklistFilterProxyModel.h
@@ -1,0 +1,61 @@
+#ifndef WORKLISTFILTERPROXYMODEL_H
+#define WORKLISTFILTERPROXYMODEL_H
+
+#include <QSortFilterProxyModel>
+#include <QDate>
+
+namespace Etrek::Application::Delegate {
+
+/**
+ * @brief Custom proxy model for filtering worklist data by date range and source.
+ *
+ * Filters are applied in-memory on the already-loaded table data.
+ * - Date filtering uses the "Created At" column (column 9)
+ * - Source filtering uses the "Source" column (column 8)
+ */
+class WorklistFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    explicit WorklistFilterProxyModel(QObject* parent = nullptr);
+
+    // Column indices for filtering
+    static constexpr int SourceColumn = 8;
+    static constexpr int CreatedAtColumn = 9;
+
+    /**
+     * @brief Set the date range filter.
+     * @param fromDate Start date (inclusive). If invalid, no lower bound.
+     * @param toDate End date (inclusive). If invalid, no upper bound.
+     */
+    void setDateRangeFilter(const QDate& fromDate, const QDate& toDate);
+
+    /**
+     * @brief Set the source filter.
+     * @param source Source string to match ("LOCAL", "RIS"). Empty string means no filter.
+     */
+    void setSourceFilter(const QString& source);
+
+    /**
+     * @brief Clear all filters and reset to defaults.
+     */
+    void clearFilters();
+
+    // Getters for current filter state
+    QDate fromDate() const { return m_fromDate; }
+    QDate toDate() const { return m_toDate; }
+    QString sourceFilter() const { return m_sourceFilter; }
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
+
+private:
+    QDate m_fromDate;
+    QDate m_toDate;
+    QString m_sourceFilter;
+};
+
+} // namespace Etrek::Application::Delegate
+
+#endif // WORKLISTFILTERPROXYMODEL_H

--- a/View/Page/WorklistPage.cpp
+++ b/View/Page/WorklistPage.cpp
@@ -1,5 +1,6 @@
 #include <QStandardItemModel>
 #include <qpointer.h>
+#include <QComboBox>
 
 #include "WorklistPage.h"
 #include "IWorklistRepository.h"
@@ -14,24 +15,42 @@ WorkListPage::WorkListPage(std::shared_ptr<IWorklistRepository> repository, QWid
     ui->setupUi(this);
     setStile();
 
+    // Set default date range: 1 year ago to today
+    QDate today = QDate::currentDate();
+    QDate oneYearAgo = today.addYears(-1);
+
+    // filterDueDateEdit is the "From" field (start date)
+    // filterStartDateEdit is the "To" field (end date)
+    ui->filterDueDateEdit->setDate(oneYearAgo);
+    ui->filterStartDateEdit->setDate(today);
+
+    // Initialize source combo box with options
+    ui->filterSourceComboBox->addItem("All");
+    ui->filterSourceComboBox->addItem("LOCAL");
+    ui->filterSourceComboBox->addItem("RIS");
+    ui->filterSourceComboBox->setCurrentIndex(0); // Default to "All"
+
+    // Lambda to emit date span when either date changes
+    // Note: filterDueDateEdit = "From" date, filterStartDateEdit = "To" date
     auto emitDateSpan = [this]() {
         DateTimeSpan span;
-        span.from = ui->filterStartDateEdit->dateTime();
-        span.to = ui->filterDueDateEdit->dateTime();
+        span.from = ui->filterDueDateEdit->dateTime();   // "From" field
+        span.to = ui->filterStartDateEdit->dateTime();   // "To" field
         emit filterDateSpanChanged(span);
-        };
-    
-        connect(ui->filterStartDateEdit, &QDateEdit::dateChanged, this, [emitDateSpan](const QDate&) {
+    };
+
+    connect(ui->filterStartDateEdit, &QDateEdit::dateChanged, this, [emitDateSpan](const QDate&) {
         emitDateSpan();
-        });
-    
-        connect(ui->filterDueDateEdit, &QDateEdit::dateChanged, this, [emitDateSpan](const QDate&) {
+    });
+
+    connect(ui->filterDueDateEdit, &QDateEdit::dateChanged, this, [emitDateSpan](const QDate&) {
         emitDateSpan();
-        });
-      
-        connect(ui->filterSourceLineEdit, &QLineEdit::textChanged, this, [this](const QString& text) {  
-           emit filterSourceChanged(text);  
-        });
+    });
+
+    // Connect source combo box
+    connect(ui->filterSourceComboBox, &QComboBox::currentTextChanged, this, [this](const QString& text) {
+        emit filterSourceChanged(text);
+    });
 
         connect(ui->clearAllFilterFieldsBtn, &QPushButton::clicked, this, [this]() {
             clearAllFilterBtnClicked();
@@ -139,8 +158,16 @@ void WorkListPage::setStile()
         "}"
         "QHeaderView::section { background: rgb(64,64,64); padding:4px; border:1px solid rgb(90,90,90); }";
 
+    const char* comboCss =
+        "QComboBox {"
+        "  border:1px solid rgb(120,120,120); border-radius:4px;"
+        "  background:rgb(74,74,74); min-height:20px; padding:2px 6px; }"
+        "QComboBox:focus { border-color: rgb(160,160,160); }"
+        "QComboBox::drop-down { width:20px; border-left:1px solid rgb(120,120,120); margin:0; }"
+        "QComboBox QAbstractItemView { background: rgb(74,74,74); selection-background-color: rgb(92,92,92); }";
+
     // Apply guarded (pointer-checked) to avoid crashes if UI changed
-    if (ui->filterSourceLineEdit) ui->filterSourceLineEdit->setStyleSheet(lineCss);
+    if (ui->filterSourceComboBox) ui->filterSourceComboBox->setStyleSheet(comboCss);
     if (ui->searchNameLineEdit) ui->searchNameLineEdit->setStyleSheet(lineCss);
     if (ui->searchPatientIdLineEdit) ui->searchPatientIdLineEdit->setStyleSheet(lineCss);
     if (ui->searchAcquisionNoLineEdit) ui->searchAcquisionNoLineEdit->setStyleSheet(lineCss);
@@ -207,12 +234,17 @@ WorkListPage::~WorkListPage()
 
 void WorkListPage::clearAllFilterBtnClicked()
 {
-     // Reset "From" date to today
-     ui->filterStartDateEdit->setDate(QDate::currentDate());
-     // Reset "To" date to today
-     ui->filterDueDateEdit->setDate(QDate::currentDate());
-     ui->filterSourceLineEdit->clear();
+    // Reset to default: 1 year ago to today
+    QDate today = QDate::currentDate();
+    QDate oneYearAgo = today.addYears(-1);
 
+    // filterDueDateEdit is the "From" field (start date)
+    // filterStartDateEdit is the "To" field (end date)
+    ui->filterDueDateEdit->setDate(oneYearAgo);
+    ui->filterStartDateEdit->setDate(today);
+
+    // Reset source filter to "All"
+    ui->filterSourceComboBox->setCurrentIndex(0);
 }
 
 void WorkListPage::clearAllSearchBtnClicked()

--- a/View/Page/WorklistPage.ui
+++ b/View/Page/WorklistPage.ui
@@ -35,7 +35,7 @@ color: rgb(208, 208, 208); </string>
        </property>
        <layout class="QFormLayout" name="formLayout">
         <item row="7" column="1">
-         <widget class="QLineEdit" name="filterSourceLineEdit">
+         <widget class="QComboBox" name="filterSourceComboBox">
           <property name="minimumSize">
            <size>
             <width>150</width>


### PR DESCRIPTION
- Create WorklistFilterProxyModel for in-memory date and source filtering
- Implement live filter updates when From/To dates or Source changes
- Set default date range to last 12 months on page load
- Change source filter from QLineEdit to QComboBox (All/LOCAL/RIS)
- Fix From/To date field mapping in DateTimeSpan emission
- Update clearAllFilterFieldsBtn to reset filters to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)