### PR TITLE
Implement Worklist search functionality and rename Study field

### DIFF
--- a/Application/Delegate/WorkListPageDelegate.cpp
+++ b/Application/Delegate/WorkListPageDelegate.cpp
@@ -53,7 +53,7 @@ namespace Etrek::Application::Delegate
         connect(ui, &WorkListPage::searchPatientId, this, &WorkListPageDelegate::onSearchPatientId);
         connect(ui, &WorkListPage::searchAcquisionNo, this, &WorkListPageDelegate::onSearchAcquisionNo);
         connect(ui, &WorkListPage::searchPatientDate, this, &WorkListPageDelegate::onSearchPatientDate);
-        connect(ui, &WorkListPage::searchStudyId, this, &WorkListPageDelegate::onSearchStudyId);
+        connect(ui, &WorkListPage::searchStudyName, this, &WorkListPageDelegate::onSearchStudyName);
 
         connect(ui, &WorkListPage::closeWorklistPage, this, [this]() {
             if (this->ui) this->closeWorklist();
@@ -248,7 +248,9 @@ namespace Etrek::Application::Delegate
 
     void WorkListPageDelegate::onClearSearch()
     {
-        proxyModel->setFilterFixedString("");
+        if (proxyModel) {
+            proxyModel->clearSearch();
+        }
     }
 
     void WorkListPageDelegate::applyFilters() {
@@ -372,22 +374,37 @@ namespace Etrek::Application::Delegate
 
     void WorkListPageDelegate::onSearchName(const QString& name)
     {
+        if (proxyModel) {
+            proxyModel->setSearchName(name);
+        }
     }
 
     void WorkListPageDelegate::onSearchPatientId(const QString& patientId)
     {
+        if (proxyModel) {
+            proxyModel->setSearchPatientId(patientId);
+        }
     }
 
-    void WorkListPageDelegate::onSearchAcquisionNo(const QString& acquisionNo)
+    void WorkListPageDelegate::onSearchAcquisionNo(const QString& accessionNo)
     {
+        if (proxyModel) {
+            proxyModel->setSearchAccessionNo(accessionNo);
+        }
     }
 
-    void WorkListPageDelegate::onSearchPatientDate(const QDate& acquisionNo)
+    void WorkListPageDelegate::onSearchPatientDate(const QDate& birthDate)
     {
+        if (proxyModel) {
+            proxyModel->setSearchBirthDate(birthDate);
+        }
     }
 
-    void WorkListPageDelegate::onSearchStudyId(const QString& studyId)
+    void WorkListPageDelegate::onSearchStudyName(const QString& studyName)
     {
+        if (proxyModel) {
+            proxyModel->setSearchStudyName(studyName);
+        }
     }
 
     QList<ent::DicomTag> WorkListPageDelegate::getDisplayTagList() const {

--- a/Application/Delegate/WorkListPageDelegate.h
+++ b/Application/Delegate/WorkListPageDelegate.h
@@ -74,7 +74,7 @@ namespace Etrek::Application::Delegate {
         void onSearchPatientId(const QString& patientId);
         void onSearchAcquisionNo(const QString& acquisionNo);
         void onSearchPatientDate(const QDate& acquisionNo);
-        void onSearchStudyId(const QString& studyId);
+        void onSearchStudyName(const QString& studyName);
 
 
 

--- a/Application/Delegate/WorklistFilterProxyModel.cpp
+++ b/Application/Delegate/WorklistFilterProxyModel.cpp
@@ -31,12 +31,54 @@ void WorklistFilterProxyModel::clearFilters()
     invalidateFilter();
 }
 
+void WorklistFilterProxyModel::setSearchName(const QString& name)
+{
+    m_searchName = name.trimmed();
+    invalidateFilter();
+}
+
+void WorklistFilterProxyModel::setSearchPatientId(const QString& patientId)
+{
+    m_searchPatientId = patientId.trimmed();
+    invalidateFilter();
+}
+
+void WorklistFilterProxyModel::setSearchStudyName(const QString& studyName)
+{
+    m_searchStudyName = studyName.trimmed();
+    invalidateFilter();
+}
+
+void WorklistFilterProxyModel::setSearchBirthDate(const QDate& birthDate)
+{
+    m_searchBirthDate = birthDate;
+    invalidateFilter();
+}
+
+void WorklistFilterProxyModel::setSearchAccessionNo(const QString& accessionNo)
+{
+    m_searchAccessionNo = accessionNo.trimmed();
+    invalidateFilter();
+}
+
+void WorklistFilterProxyModel::clearSearch()
+{
+    m_searchName.clear();
+    m_searchPatientId.clear();
+    m_searchStudyName.clear();
+    m_searchBirthDate = QDate();
+    m_searchAccessionNo.clear();
+    invalidateFilter();
+}
+
 bool WorklistFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const
 {
     // Get the source model
     QAbstractItemModel* model = sourceModel();
     if (!model)
         return true;
+
+    // ===== FILTER CHECKS =====
 
     // Check source filter (column 8)
     if (!m_sourceFilter.isEmpty()) {
@@ -73,6 +115,51 @@ bool WorklistFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex
             if (m_toDate.isValid() && rowDate > m_toDate)
                 return false;
         }
+    }
+
+    // ===== SEARCH CHECKS (applied on top of filters) =====
+
+    // Check name search (column 0 - Patient Name) - contains match
+    if (!m_searchName.isEmpty()) {
+        QModelIndex nameIndex = model->index(sourceRow, PatientNameColumn, sourceParent);
+        QString nameValue = model->data(nameIndex).toString();
+        if (!nameValue.contains(m_searchName, Qt::CaseInsensitive))
+            return false;
+    }
+
+    // Check patient ID search (column 1) - contains match
+    if (!m_searchPatientId.isEmpty()) {
+        QModelIndex patientIdIndex = model->index(sourceRow, PatientIdColumn, sourceParent);
+        QString patientIdValue = model->data(patientIdIndex).toString();
+        if (!patientIdValue.contains(m_searchPatientId, Qt::CaseInsensitive))
+            return false;
+    }
+
+    // Check study name search (column 2) - contains match
+    if (!m_searchStudyName.isEmpty()) {
+        QModelIndex studyNameIndex = model->index(sourceRow, StudyNameColumn, sourceParent);
+        QString studyNameValue = model->data(studyNameIndex).toString();
+        if (!studyNameValue.contains(m_searchStudyName, Qt::CaseInsensitive))
+            return false;
+    }
+
+    // Check birth date search (column 4) - exact date match
+    if (m_searchBirthDate.isValid()) {
+        QModelIndex birthDateIndex = model->index(sourceRow, BirthDateColumn, sourceParent);
+        QString birthDateStr = model->data(birthDateIndex).toString();
+
+        // Parse the date from "yyyy-MM-dd" format
+        QDate rowBirthDate = QDate::fromString(birthDateStr, "yyyy-MM-dd");
+        if (!rowBirthDate.isValid() || rowBirthDate != m_searchBirthDate)
+            return false;
+    }
+
+    // Check accession number search (column 5) - contains match
+    if (!m_searchAccessionNo.isEmpty()) {
+        QModelIndex accessionNoIndex = model->index(sourceRow, AccessionNoColumn, sourceParent);
+        QString accessionNoValue = model->data(accessionNoIndex).toString();
+        if (!accessionNoValue.contains(m_searchAccessionNo, Qt::CaseInsensitive))
+            return false;
     }
 
     return true;

--- a/Application/Delegate/WorklistFilterProxyModel.h
+++ b/Application/Delegate/WorklistFilterProxyModel.h
@@ -7,11 +7,14 @@
 namespace Etrek::Application::Delegate {
 
 /**
- * @brief Custom proxy model for filtering worklist data by date range and source.
+ * @brief Custom proxy model for filtering and searching worklist data.
  *
- * Filters are applied in-memory on the already-loaded table data.
+ * Filters and search are applied in-memory on the already-loaded table data.
  * - Date filtering uses the "Created At" column (column 9)
  * - Source filtering uses the "Source" column (column 8)
+ * - Search operates on: Name (0), Patient ID (1), Study Name (2), Birth Date (4), Accession No (5)
+ *
+ * Search is applied ON TOP of filters - rows must match both filters AND search criteria.
  */
 class WorklistFilterProxyModel : public QSortFilterProxyModel
 {
@@ -20,7 +23,12 @@ class WorklistFilterProxyModel : public QSortFilterProxyModel
 public:
     explicit WorklistFilterProxyModel(QObject* parent = nullptr);
 
-    // Column indices for filtering
+    // Column indices for filtering and searching
+    static constexpr int PatientNameColumn = 0;
+    static constexpr int PatientIdColumn = 1;
+    static constexpr int StudyNameColumn = 2;
+    static constexpr int BirthDateColumn = 4;
+    static constexpr int AccessionNoColumn = 5;
     static constexpr int SourceColumn = 8;
     static constexpr int CreatedAtColumn = 9;
 
@@ -38,9 +46,21 @@ public:
     void setSourceFilter(const QString& source);
 
     /**
-     * @brief Clear all filters and reset to defaults.
+     * @brief Clear all filters and reset to defaults (does NOT clear search).
      */
     void clearFilters();
+
+    // Search criteria setters
+    void setSearchName(const QString& name);
+    void setSearchPatientId(const QString& patientId);
+    void setSearchStudyName(const QString& studyName);
+    void setSearchBirthDate(const QDate& birthDate);
+    void setSearchAccessionNo(const QString& accessionNo);
+
+    /**
+     * @brief Clear all search criteria (does NOT clear filters).
+     */
+    void clearSearch();
 
     // Getters for current filter state
     QDate fromDate() const { return m_fromDate; }
@@ -51,9 +71,17 @@ protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
 
 private:
+    // Filter state
     QDate m_fromDate;
     QDate m_toDate;
     QString m_sourceFilter;
+
+    // Search state
+    QString m_searchName;
+    QString m_searchPatientId;
+    QString m_searchStudyName;
+    QDate m_searchBirthDate;
+    QString m_searchAccessionNo;
 };
 
 } // namespace Etrek::Application::Delegate

--- a/View/Page/WorklistPage.cpp
+++ b/View/Page/WorklistPage.cpp
@@ -58,12 +58,7 @@ WorkListPage::WorkListPage(std::shared_ptr<IWorklistRepository> repository, QWid
             });
 
         connect(ui->clearAllSearchFieldsBtn, &QPushButton::clicked, this, [this]() {
-            clearAllFilterBtnClicked();
-            emit clearAllFilters();
-            });
-
-        connect(ui->clearAllSearchFieldsBtn, &QPushButton::clicked, this, [this]() {
-            clearAllFilterBtnClicked();
+            clearAllSearchBtnClicked();
             emit clearAllSearch();
             });
     
@@ -83,8 +78,8 @@ WorkListPage::WorkListPage(std::shared_ptr<IWorklistRepository> repository, QWid
             emit searchPatientDate(date);
             });
         
-        connect(ui->searchStudyIdTextEdit, &QLineEdit::textChanged, this, [this](const QString& text) {
-            emit searchStudyId(text);
+        connect(ui->searchStudyNameTextEdit, &QLineEdit::textChanged, this, [this](const QString& text) {
+            emit searchStudyName(text);
             });
 
         // Emit signal for delegate to handle Add New Patient dialog
@@ -171,7 +166,7 @@ void WorkListPage::setStile()
     if (ui->searchNameLineEdit) ui->searchNameLineEdit->setStyleSheet(lineCss);
     if (ui->searchPatientIdLineEdit) ui->searchPatientIdLineEdit->setStyleSheet(lineCss);
     if (ui->searchAcquisionNoLineEdit) ui->searchAcquisionNoLineEdit->setStyleSheet(lineCss);
-    if (ui->searchStudyIdTextEdit) ui->searchStudyIdTextEdit->setStyleSheet(lineCss);
+    if (ui->searchStudyNameTextEdit) ui->searchStudyNameTextEdit->setStyleSheet(lineCss);
 
     if (ui->filterStartDateEdit) ui->filterStartDateEdit->setStyleSheet(dateCss);
     if (ui->filterDueDateEdit) ui->filterDueDateEdit->setStyleSheet(dateCss);
@@ -249,14 +244,12 @@ void WorkListPage::clearAllFilterBtnClicked()
 
 void WorkListPage::clearAllSearchBtnClicked()
 {
-	ui->searchNameLineEdit->clear();
-	ui->searchPatientIdLineEdit->clear();
-	ui->searchAcquisionNoLineEdit->clear();
-	// Reset birth date to a reasonable default (e.g., today or leave as is)
-	ui->searchPatientBirthDateDateEdit->setDate(QDate::currentDate());
-	ui->searchStudyIdTextEdit->clear();
-
-
+    ui->searchNameLineEdit->clear();
+    ui->searchPatientIdLineEdit->clear();
+    ui->searchAcquisionNoLineEdit->clear();
+    // Clear birth date by setting to invalid/null date (empty search)
+    ui->searchPatientBirthDateDateEdit->clear();
+    ui->searchStudyNameTextEdit->clear();
 }
 
 // Removed: onAddNewPatientClicked. Dialog is launched elsewhere in workflow.

--- a/View/Page/WorklistPage.h
+++ b/View/Page/WorklistPage.h
@@ -43,7 +43,7 @@ signals:
     void searchPatientId(const QString& patientId);
     void searchAcquisionNo(const QString& acquisionNo);
     void searchPatientDate(const QDate& acquisionNo);
-    void searchStudyId(const QString& studyId);
+    void searchStudyName(const QString& studyName);
 
 private:
     void clearAllFilterBtnClicked();

--- a/View/Page/WorklistPage.ui
+++ b/View/Page/WorklistPage.ui
@@ -349,19 +349,19 @@ color: rgb(208, 208, 208); </string>
          </widget>
         </item>
         <item row="4" column="0">
-         <widget class="QLabel" name="searchStudyIdLbl">
+         <widget class="QLabel" name="searchStudyNameLbl">
           <property name="font">
            <font>
             <pointsize>11</pointsize>
            </font>
           </property>
           <property name="text">
-           <string>Study Id</string>
+           <string>Study Name</string>
           </property>
          </widget>
         </item>
         <item row="4" column="1">
-         <widget class="QLineEdit" name="searchStudyIdTextEdit">
+         <widget class="QLineEdit" name="searchStudyNameTextEdit">
           <property name="minimumSize">
            <size>
             <width>150</width>


### PR DESCRIPTION
- Rename searchStudyIdTextEdit to searchStudyNameTextEdit (UI, signals, slots)
- Update label from "Study Id" to "Study Name" in searchGroupBox
- Add search criteria to WorklistFilterProxyModel:
  - Name (column 0) - contains match
  - Patient ID (column 1) - contains match
  - Study Name (column 2) - contains match
  - Birth Date (column 4) - exact match
  - Accession No (column 5) - contains match
- Search applies ON TOP of filters (rows must match both)
- Fix clearAllSearchFieldsBtn to only clear search, not filters
- Implement live search updates as user types

🤖 Generated with [Claude Code](https://claude.com/claude-code)