### PR TITLE
Add close functionality to ImageViewerPage

### DIFF
--- a/Application/Delegate/ImageViewerPageDelegate.cpp
+++ b/Application/Delegate/ImageViewerPageDelegate.cpp
@@ -149,6 +149,10 @@ void ImageViewerPageDelegate::setupConnections() {
     // Thumbnails
     connect(m_ui, &ImageViewerPage::thumbnailClicked,
             this, &ImageViewerPageDelegate::onThumbnailClicked);
+
+    // Close request - user wants to close ImageViewer and return to main window
+    connect(m_ui, &ImageViewerPage::closeRequested,
+            this, &ImageViewerPageDelegate::reject);
 }
 
 void ImageViewerPageDelegate::loadFromFile(const QString& filePath) {

--- a/View/Page/ImageViewerPage.cpp
+++ b/View/Page/ImageViewerPage.cpp
@@ -8,6 +8,7 @@
 #include <QVTKOpenGLNativeWidget.h>
 #include <QHBoxLayout>
 #include <QSplitter>
+#include <QDialogButtonBox>
 #include <QDragEnterEvent>
 #include <QDropEvent>
 #include <QMimeData>
@@ -42,12 +43,11 @@ ImageViewerPage::ImageViewerPage(QWidget* parent)
     // Set initial sizes
     mainSplitter->setSizes({60, 700, 150});
 
-    // Add splitter to main layout
-    QHBoxLayout* mainLayout = new QHBoxLayout(this);
-    mainLayout->setContentsMargins(0, 0, 0, 0);
-    mainLayout->setSpacing(0);
-    mainLayout->addWidget(mainSplitter);
-    setLayout(mainLayout);
+    // Add splitter to the content area defined in UI (above the buttonBox)
+    QHBoxLayout* contentLayout = new QHBoxLayout(ui->contentArea);
+    contentLayout->setContentsMargins(0, 0, 0, 0);
+    contentLayout->setSpacing(0);
+    contentLayout->addWidget(mainSplitter);
 
     // Enable drag and drop
     setAcceptDrops(true);
@@ -55,8 +55,10 @@ ImageViewerPage::ImageViewerPage(QWidget* parent)
     // Setup signal connections
     setupConnections();
 
-    // Apply dark theme
-    setStyleSheet("background-color: rgb(30, 30, 30);");
+    // Connect buttonBox signals (similar to SystemSettingPage pattern)
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, [this]() {
+        emit closeRequested();
+    });
 }
 
 ImageViewerPage::~ImageViewerPage() {
@@ -217,6 +219,10 @@ void ImageViewerPage::keyPressEvent(QKeyEvent* event) {
             if (event->modifiers() & Qt::ControlModifier) {
                 emit openFileRequested();
             }
+            break;
+        case Qt::Key_Escape:
+            // Escape key closes the ImageViewer and returns to main window
+            emit closeRequested();
             break;
         default:
             QWidget::keyPressEvent(event);

--- a/View/Page/ImageViewerPage.h
+++ b/View/Page/ImageViewerPage.h
@@ -84,6 +84,9 @@ signals:
     // Drag and drop
     void filesDropped(const QStringList& filePaths);
 
+    // Close request - emitted when user wants to close ImageViewer
+    void closeRequested();
+
 protected:
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;

--- a/View/Page/ImageViewerPage.ui
+++ b/View/Page/ImageViewerPage.ui
@@ -25,6 +25,48 @@
   <property name="acceptDrops">
    <bool>true</bool>
   </property>
+  <layout class="QVBoxLayout" name="mainLayout">
+   <property name="spacing">
+    <number>4</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="contentArea" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: rgb(208, 208, 208);</string>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
Introduced a `closeRequested` signal in `ImageViewerPage` to handle closing the viewer via Escape key or Close button. Updated the UI to include a `QDialogButtonBox` with a Close button and restructured the layout to use a `contentArea`. Connected the `closeRequested` signal to `ImageViewerPageDelegate` for proper handling.

Removed the dark theme application and refactored layout management for better organization and maintainability.