### PR TITLE
Improve cursor updates and panning behavior

### DIFF
--- a/Application/Delegate/ImageViewerPageDelegate.cpp
+++ b/Application/Delegate/ImageViewerPageDelegate.cpp
@@ -105,6 +105,23 @@ void ImageViewerPageDelegate::initializeTools() {
     connect(m_resetTool.get(), &ResetTool::resetRequested,
             this, &ImageViewerPageDelegate::onResetRequested);
 
+    // Connect cursor change signals from all tools
+    connect(m_windowLevelTool.get(), &WindowLevelTool::cursorChanged,
+            this, &ImageViewerPageDelegate::onCursorChanged);
+    connect(m_zoomTool.get(), &ZoomTool::cursorChanged,
+            this, &ImageViewerPageDelegate::onCursorChanged);
+    connect(m_panTool.get(), &PanTool::cursorChanged,
+            this, &ImageViewerPageDelegate::onCursorChanged);
+    connect(m_rulerTool.get(), &RulerTool::cursorChanged,
+            this, &ImageViewerPageDelegate::onCursorChanged);
+    connect(m_angleTool.get(), &AngleTool::cursorChanged,
+            this, &ImageViewerPageDelegate::onCursorChanged);
+    connect(m_resetTool.get(), &ResetTool::cursorChanged,
+            this, &ImageViewerPageDelegate::onCursorChanged);
+
+    // Set pan tool sensitivity for more responsive panning
+    m_panTool->setSensitivity(2.0);
+
     // Activate default tool
     activateTool(ToolType::WINDOW_LEVEL);
 }
@@ -481,6 +498,18 @@ void ImageViewerPageDelegate::onMeasurementLineUpdated(const MeasurementLine& li
 void ImageViewerPageDelegate::onMeasurementLineCompleted(const MeasurementLine& line) {
     Q_UNUSED(line)
     // TODO: Store measurement and update visualization
+}
+
+void ImageViewerPageDelegate::onCursorChanged(Qt::CursorShape cursor) {
+    // Apply cursor to all visible viewport widgets
+    auto widgets = m_ui->getAllVtkWidgets();
+    int visibleCount = m_viewportManager->visibleViewportCount();
+
+    for (int i = 0; i < visibleCount; ++i) {
+        if (widgets[i]) {
+            widgets[i]->setCursor(cursor);
+        }
+    }
 }
 
 void ImageViewerPageDelegate::updateOverlay(int viewportIndex) {

--- a/Application/Delegate/ImageViewerPageDelegate.h
+++ b/Application/Delegate/ImageViewerPageDelegate.h
@@ -131,6 +131,7 @@ private slots:
     void onResetRequested();
     void onMeasurementLineUpdated(const Etrek::ImageViewer::MeasurementLine& line);
     void onMeasurementLineCompleted(const Etrek::ImageViewer::MeasurementLine& line);
+    void onCursorChanged(Qt::CursorShape cursor);
 
 private:
     void initializeViewports();

--- a/ImageViewer/Rendering/VtkViewportRenderer.cpp
+++ b/ImageViewer/Rendering/VtkViewportRenderer.cpp
@@ -353,8 +353,11 @@ void VtkViewportRenderer::setPan(double deltaX, double deltaY) {
         double* focalPoint = camera->GetFocalPoint();
         double* position = camera->GetPosition();
 
-        camera->SetFocalPoint(focalPoint[0] - deltaX, focalPoint[1] - deltaY, focalPoint[2]);
-        camera->SetPosition(position[0] - deltaX, position[1] - deltaY, position[2]);
+        // Move camera for intuitive "drag the image" behavior
+        // X: + because drag right should move image right
+        // Y: - because Y-axis is flipped (SetViewUp 0,-1,0), so drag up should move image up
+        camera->SetFocalPoint(focalPoint[0] + deltaX, focalPoint[1] - deltaY, focalPoint[2]);
+        camera->SetPosition(position[0] + deltaX, position[1] - deltaY, position[2]);
     }
 
     render();


### PR DESCRIPTION
Added connections in `ImageViewerPageDelegate::initializeTools` to handle `cursorChanged` signals from various tools and route them to the new `onCursorChanged` method. The `onCursorChanged` method updates the cursor shape for all visible viewport widgets dynamically.

Enhanced `initializeTools` by setting the `PanTool` sensitivity to `2.0` for smoother and more responsive panning.

Modified `VtkViewportRenderer::setPan` to adjust the camera's focal point and position for a more intuitive "drag the image" behavior:
- Dragging right moves the image right (positive X-axis adjustment).
- Dragging up moves the image up (negative Y-axis adjustment due to flipped Y-axis).

Declared the `onCursorChanged` slot in `ImageViewerPageDelegate.h` to handle cursor change events.