### PR TITLE
Add EdgeRulerWidget for calibrated image measurements

### DIFF
--- a/Application/Delegate/ImageViewerPageDelegate.cpp
+++ b/Application/Delegate/ImageViewerPageDelegate.cpp
@@ -17,6 +17,7 @@
 #include "MagnifierWidget.h"
 #include "RulerOverlayWidget.h"
 #include "AngleOverlayWidget.h"
+#include "EdgeRulerWidget.h"
 
 #include <QTimer>
 #include <QFileDialog>
@@ -71,6 +72,11 @@ bool ImageViewerPageDelegate::eventFilter(QObject* watched, QEvent* event) {
                     m_angleOverlays[i]->setGeometry(0, 0, widgets[i]->width(), widgets[i]->height());
                     m_angleOverlays[i]->refresh();
                 }
+                // Resize edge ruler overlay to match the VTK widget
+                if (m_edgeRulers[i]) {
+                    m_edgeRulers[i]->setGeometry(0, 0, widgets[i]->width(), widgets[i]->height());
+                    m_edgeRulers[i]->update();
+                }
                 break;
             }
         }
@@ -101,6 +107,7 @@ void ImageViewerPageDelegate::onPageLoaded() {
     initializeViewports();
     initializeRulerOverlays();
     initializeAngleOverlays();
+    initializeEdgeRulers();
 
     // Check if there's context data to load
     if (auto ctx = m_contextManager.lock()) {
@@ -189,6 +196,64 @@ void ImageViewerPageDelegate::initializeAngleOverlays() {
             }
         }
     }
+}
+
+void ImageViewerPageDelegate::initializeEdgeRulers() {
+    auto widgets = m_ui->getAllVtkWidgets();
+
+    for (int i = 0; i < 4; ++i) {
+        if (widgets[i]) {
+            // Parent to the VTK widget directly so overlay matches its size
+            m_edgeRulers[i] = new EdgeRulerWidget(widgets[i]);
+            m_edgeRulers[i]->setGeometry(0, 0, widgets[i]->width(), widgets[i]->height());
+            m_edgeRulers[i]->raise();
+            m_edgeRulers[i]->show();
+
+            // Initially hide until an image is loaded
+            m_edgeRulers[i]->setVisible(false);
+        }
+    }
+}
+
+void ImageViewerPageDelegate::updateEdgeRulers(int viewportIndex) {
+    if (viewportIndex < 0 || viewportIndex >= 4) return;
+    if (!m_edgeRulers[viewportIndex]) return;
+
+    auto* renderer = m_viewportManager->getRenderer(viewportIndex);
+    if (!renderer || !renderer->hasImage()) {
+        m_edgeRulers[viewportIndex]->setVisible(false);
+        return;
+    }
+
+    // Get pixel spacing from metadata
+    const auto& meta = m_viewportMetadata[viewportIndex];
+    double spacingX = meta.pixelSpacingX;
+    double spacingY = meta.pixelSpacingY;
+
+    // If pixel spacing is invalid, hide the ruler
+    if (spacingX <= 0 || spacingY <= 0) {
+        m_edgeRulers[viewportIndex]->setVisible(false);
+        return;
+    }
+
+    // Get image dimensions
+    int imageWidth, imageHeight;
+    renderer->getImageDimensions(imageWidth, imageHeight);
+
+    // Update edge ruler with image info
+    m_edgeRulers[viewportIndex]->setPixelSpacing(spacingX, spacingY);
+    m_edgeRulers[viewportIndex]->setImageDimensions(imageWidth, imageHeight);
+    m_edgeRulers[viewportIndex]->setZoomLevel(renderer->getZoom());
+
+    // Set coordinate transform for converting image coords to widget coords
+    m_edgeRulers[viewportIndex]->setImageToWidgetTransform(
+        [renderer](const QPointF& imagePos) {
+            return renderer->imageToWidgetCoords(imagePos);
+        }
+    );
+
+    m_edgeRulers[viewportIndex]->setVisible(true);
+    m_edgeRulers[viewportIndex]->update();
 }
 
 void ImageViewerPageDelegate::refreshAngleOverlays() {
@@ -461,6 +526,7 @@ void ImageViewerPageDelegate::loadImageIntoViewport(int viewportIndex, const QSt
             renderer->fitToWindow();
 
             updateOverlay(viewportIndex);
+            updateEdgeRulers(viewportIndex);
             emit imageLoaded(viewportIndex);
         }
     } else {
@@ -663,6 +729,7 @@ void ImageViewerPageDelegate::onViewportMouseWheel(int viewportIndex, int delta,
         double zoomFactor = delta > 0 ? 1.1 : 0.9;
         renderer->setZoom(currentZoom * zoomFactor);
         updateOverlay(m_activeViewportIndex);
+        updateEdgeRulers(m_activeViewportIndex);
         refreshRulerOverlays();
         refreshAngleOverlays();
     }
@@ -678,6 +745,7 @@ void ImageViewerPageDelegate::onViewportDoubleClicked(int viewportIndex, const Q
         if (auto* renderer = m_viewportManager->activeRenderer()) {
             renderer->fitToWindow();
             updateOverlay(m_activeViewportIndex);
+            updateEdgeRulers(m_activeViewportIndex);
             refreshRulerOverlays();
             refreshAngleOverlays();
         }
@@ -719,6 +787,7 @@ void ImageViewerPageDelegate::onResetViewRequested() {
         renderer->resetCamera();
         renderer->resetWindowLevel();
         updateOverlay(m_activeViewportIndex);
+        updateEdgeRulers(m_activeViewportIndex);
     }
 
     // Clear all ruler measurements
@@ -758,6 +827,9 @@ void ImageViewerPageDelegate::onFitToWindowRequested() {
     if (auto* renderer = m_viewportManager->activeRenderer()) {
         renderer->fitToWindow();
         updateOverlay(m_activeViewportIndex);
+        updateEdgeRulers(m_activeViewportIndex);
+        refreshRulerOverlays();
+        refreshAngleOverlays();
     }
 }
 
@@ -786,6 +858,7 @@ void ImageViewerPageDelegate::onZoomRequested(double factor, const QPointF& cent
     if (auto* renderer = m_viewportManager->activeRenderer()) {
         renderer->setZoom(factor);
         updateOverlay(m_activeViewportIndex);
+        updateEdgeRulers(m_activeViewportIndex);
         refreshRulerOverlays();
         refreshAngleOverlays();
     }
@@ -990,40 +1063,93 @@ QString ImageViewerPageDelegate::formatOverlayText(OverlayCorner corner, int vie
 
     switch (corner) {
         case OverlayCorner::TOP_LEFT: {
+            // Patient demographics
             QString text;
             if (!meta.patientName.isEmpty()) {
                 text += meta.patientName + "\n";
             }
             if (!meta.patientId.isEmpty()) {
-                text += "ID: " + meta.patientId;
+                text += "ID: " + meta.patientId + "\n";
+            }
+            // Add birth date and sex on same line if available
+            QString demographics;
+            if (!meta.patientBirthDate.isEmpty()) {
+                demographics += "DOB: " + meta.patientBirthDate;
+            }
+            if (!meta.patientSex.isEmpty()) {
+                if (!demographics.isEmpty()) demographics += "  ";
+                demographics += meta.patientSex;
+            }
+            if (!demographics.isEmpty()) {
+                text += demographics;
+            }
+            // Remove trailing newline if present
+            while (text.endsWith('\n')) {
+                text.chop(1);
             }
             return text;
         }
         case OverlayCorner::TOP_RIGHT: {
+            // Study information
             QString text;
             if (!meta.studyDate.isEmpty()) {
                 text += meta.studyDate;
+                if (!meta.studyTime.isEmpty()) {
+                    // Format time if available (take first 6 chars: HHMMSS)
+                    QString time = meta.studyTime.left(6);
+                    if (time.length() >= 4) {
+                        text += " " + time.left(2) + ":" + time.mid(2, 2);
+                    }
+                }
+                text += "\n";
+            }
+            if (!meta.studyDescription.isEmpty()) {
+                text += meta.studyDescription + "\n";
+            }
+            if (!meta.accessionNumber.isEmpty()) {
+                text += "Acc#: " + meta.accessionNumber;
+            }
+            // Remove trailing newline if present
+            while (text.endsWith('\n')) {
+                text.chop(1);
             }
             return text;
         }
         case OverlayCorner::BOTTOM_LEFT: {
+            // Technical parameters
             double window, level;
             renderer->getWindowLevel(window, level);
             double zoom = renderer->getZoom();
 
-            return QString("Zoom: %1%\nWW/WL: %2/%3")
+            QString text = QString("Zoom: %1%\nWW/WL: %2/%3")
                 .arg(static_cast<int>(zoom * 100))
                 .arg(static_cast<int>(window))
                 .arg(static_cast<int>(level));
+
+            // Add modality if available
+            if (!meta.modality.isEmpty()) {
+                text += "\n" + meta.modality;
+            }
+
+            return text;
         }
         case OverlayCorner::BOTTOM_RIGHT: {
+            // Image/Series information
             QString text;
             if (meta.instanceNumber > 0) {
-                text += QString("Image: %1").arg(meta.instanceNumber);
+                if (meta.totalImages > 1) {
+                    text += QString("Image: %1/%2").arg(meta.instanceNumber).arg(meta.totalImages);
+                } else {
+                    text += QString("Image: %1").arg(meta.instanceNumber);
+                }
             }
             if (!meta.seriesDescription.isEmpty()) {
                 if (!text.isEmpty()) text += "\n";
                 text += meta.seriesDescription;
+            }
+            if (!meta.bodyPartExamined.isEmpty()) {
+                if (!text.isEmpty()) text += "\n";
+                text += meta.bodyPartExamined;
             }
             return text;
         }

--- a/Application/Delegate/ImageViewerPageDelegate.h
+++ b/Application/Delegate/ImageViewerPageDelegate.h
@@ -36,6 +36,7 @@ namespace Etrek::ImageViewer::Widget {
 class MagnifierWidget;
 class RulerOverlayWidget;
 class AngleOverlayWidget;
+class EdgeRulerWidget;
 }
 
 namespace Etrek::Dicom::Repository {
@@ -164,6 +165,7 @@ private:
     void initializeTools();
     void initializeRulerOverlays();
     void initializeAngleOverlays();
+    void initializeEdgeRulers();
     void setupConnections();
     void updateOverlay(int viewportIndex);
     void updateAllOverlays();
@@ -174,6 +176,7 @@ private:
     void updateRulerOverlayTransforms();
     void refreshAngleOverlays();
     void updateAngleOverlayTransforms();
+    void updateEdgeRulers(int viewportIndex);
 
     // UI
     ImageViewerPage* m_ui;
@@ -205,6 +208,9 @@ private:
 
     // Angle overlay widgets (one per viewport)
     std::array<Etrek::ImageViewer::Widget::AngleOverlayWidget*, 4> m_angleOverlays = {nullptr, nullptr, nullptr, nullptr};
+
+    // Edge ruler widgets (one per viewport)
+    std::array<Etrek::ImageViewer::Widget::EdgeRulerWidget*, 4> m_edgeRulers = {nullptr, nullptr, nullptr, nullptr};
 
     // State
     Etrek::ImageViewer::ToolType m_currentTool = Etrek::ImageViewer::ToolType::WINDOW_LEVEL;

--- a/ImageViewer/Widget/EdgeRulerWidget.cpp
+++ b/ImageViewer/Widget/EdgeRulerWidget.cpp
@@ -1,0 +1,330 @@
+#include "EdgeRulerWidget.h"
+
+#include <QPainter>
+#include <QPen>
+#include <QFont>
+#include <cmath>
+#include <algorithm>
+
+namespace Etrek::ImageViewer::Widget {
+
+EdgeRulerWidget::EdgeRulerWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    // Set up the widget as a transparent overlay
+    setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_TransparentForMouseEvents);
+    setMouseTracking(false);
+}
+
+void EdgeRulerWidget::setPixelSpacing(double spacingX, double spacingY) {
+    m_pixelSpacingX = spacingX;
+    m_pixelSpacingY = spacingY;
+    update();
+}
+
+void EdgeRulerWidget::setImageDimensions(int width, int height) {
+    m_imageWidth = width;
+    m_imageHeight = height;
+    update();
+}
+
+void EdgeRulerWidget::setZoomLevel(double zoom) {
+    m_zoomLevel = zoom;
+    update();
+}
+
+void EdgeRulerWidget::setImageToWidgetTransform(CoordinateTransform transform) {
+    m_imageToWidget = std::move(transform);
+    update();
+}
+
+void EdgeRulerWidget::setShowHorizontalRuler(bool show) {
+    m_showHorizontal = show;
+    update();
+}
+
+void EdgeRulerWidget::setShowVerticalRuler(bool show) {
+    m_showVertical = show;
+    update();
+}
+
+void EdgeRulerWidget::setRulerColor(const QColor& color) {
+    m_rulerColor = color;
+    update();
+}
+
+void EdgeRulerWidget::setRulerWidth(int rulerWidth) {
+    m_rulerWidth = rulerWidth;
+    update();
+}
+
+QPointF EdgeRulerWidget::transformToWidget(const QPointF& imagePos) const {
+    if (m_imageToWidget) {
+        return m_imageToWidget(imagePos);
+    }
+    return imagePos;
+}
+
+double EdgeRulerWidget::calculateTickInterval() const {
+    // Calculate the display size of 1mm at current zoom
+    double mmPerDisplayPixel = m_pixelSpacingY / m_zoomLevel;
+    double pixelsPerMm = 1.0 / mmPerDisplayPixel;
+
+    // Choose tick interval so ticks are at least 3 pixels apart
+    if (pixelsPerMm >= 3.0) {
+        return 1.0;   // 1mm ticks
+    } else if (pixelsPerMm >= 0.6) {
+        return 5.0;   // 5mm ticks
+    } else if (pixelsPerMm >= 0.3) {
+        return 10.0;  // 1cm ticks
+    } else {
+        return 50.0;  // 5cm ticks
+    }
+}
+
+void EdgeRulerWidget::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event)
+
+    if (!m_imageToWidget || m_imageWidth <= 0 || m_imageHeight <= 0) {
+        return;
+    }
+
+    if (m_pixelSpacingX <= 0 || m_pixelSpacingY <= 0) {
+        return;
+    }
+
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    if (m_showVertical) {
+        drawVerticalRuler(painter);
+    }
+
+    if (m_showHorizontal) {
+        drawHorizontalRuler(painter);
+    }
+}
+
+void EdgeRulerWidget::drawVerticalRuler(QPainter& painter) {
+    // Get the image corners in widget coordinates
+    QPointF imageTopRight = transformToWidget(QPointF(m_imageWidth, 0));
+    QPointF imageBottomRight = transformToWidget(QPointF(m_imageWidth, m_imageHeight));
+    QPointF imageTopLeft = transformToWidget(QPointF(0, 0));
+
+    // Check if the right edge of the image is visible
+    if (imageTopRight.x() < 0 || imageTopRight.x() > width()) {
+        return;  // Image right edge not visible in widget
+    }
+
+    // Calculate the visible portion of the image (clamp to widget bounds)
+    int imageTop = static_cast<int>(std::max(0.0, imageTopRight.y()));
+    int imageBottom = static_cast<int>(std::min(static_cast<double>(height()), imageBottomRight.y()));
+
+    if (imageTop >= imageBottom) {
+        return;  // No visible vertical range
+    }
+
+    // Ruler X position - at the right edge of the image
+    int rulerX = static_cast<int>(imageTopRight.x());
+
+    // Draw ruler background - only within image bounds
+    QRect rulerRect(rulerX, imageTop, m_rulerWidth, imageBottom - imageTop);
+    painter.fillRect(rulerRect, QColor(0, 0, 0, 180));
+
+    // Draw ruler left border (the line along image edge)
+    painter.setPen(QPen(m_rulerColor, 1));
+    painter.drawLine(rulerX, imageTop, rulerX, imageBottom);
+
+    // Calculate physical dimensions
+    double imageSizeMm = m_imageHeight * m_pixelSpacingY;
+
+    // Determine tick interval based on zoom
+    double tickInterval = calculateTickInterval();
+    double majorInterval = (tickInterval <= 5.0) ? 10.0 : 50.0;  // Major ticks at cm or 5cm
+
+    // Set up font for labels
+    QFont font("Arial", FONT_SIZE);
+    painter.setFont(font);
+    QFontMetrics fm(font);
+
+    // Draw "cm" label at top of ruler (if space available)
+    if (imageTop < height() - 20) {
+        painter.setPen(m_rulerColor);
+        QString unitLabel = "cm";
+        int unitX = rulerX + (m_rulerWidth - fm.horizontalAdvance(unitLabel)) / 2;
+        int unitY = imageTop + fm.height() + 2;
+        painter.drawText(unitX, unitY, unitLabel);
+    }
+
+    // Calculate total number of ticks (use integer math to avoid floating point issues)
+    int tickIntervalUm = static_cast<int>(tickInterval * 1000);  // Convert to micrometers
+    int majorIntervalUm = static_cast<int>(majorInterval * 1000);
+    int totalUm = static_cast<int>(imageSizeMm * 1000);
+
+    // Draw ticks from 0 to image height
+    for (int um = 0; um <= totalUm; um += tickIntervalUm) {
+        double mm = um / 1000.0;
+
+        // Convert mm position to image pixel position
+        double imageY = mm / m_pixelSpacingY;
+
+        // Transform to widget coordinates
+        QPointF widgetPos = transformToWidget(QPointF(m_imageWidth, imageY));
+
+        // Only draw ticks within the image bounds (in widget space)
+        if (widgetPos.y() < imageTop || widgetPos.y() > imageBottom) {
+            continue;
+        }
+
+        int y = static_cast<int>(widgetPos.y());
+        int tickLength;
+        bool drawLabel = false;
+
+        // Determine tick type using integer modulo (no floating point errors)
+        if (um % majorIntervalUm == 0) {
+            // Major tick (cm)
+            tickLength = MAJOR_TICK_LENGTH;
+            drawLabel = (um > 0);  // Don't label 0
+        } else if (um % 5000 == 0) {
+            // Medium tick (5mm = 5000um)
+            tickLength = MEDIUM_TICK_LENGTH;
+        } else {
+            // Minor tick (1mm)
+            tickLength = MINOR_TICK_LENGTH;
+        }
+
+        // Draw tick mark
+        painter.setPen(QPen(m_rulerColor, 1));
+        painter.drawLine(rulerX, y, rulerX + tickLength, y);
+
+        // Draw label at major ticks
+        if (drawLabel) {
+            int cm = um / 10000;  // 10000um = 1cm
+            QString label = QString::number(cm);
+
+            int textY = y + fm.ascent() / 2 - 1;
+            int textX = rulerX + tickLength + LABEL_MARGIN;
+
+            // Draw text with shadow for visibility
+            painter.setPen(QColor(0, 0, 0));
+            painter.drawText(textX + 1, textY + 1, label);
+            painter.setPen(m_rulerColor);
+            painter.drawText(textX, textY, label);
+        }
+    }
+}
+
+void EdgeRulerWidget::drawHorizontalRuler(QPainter& painter) {
+    // Get the image corners in widget coordinates
+    QPointF imageBottomLeft = transformToWidget(QPointF(0, m_imageHeight));
+    QPointF imageBottomRight = transformToWidget(QPointF(m_imageWidth, m_imageHeight));
+
+    // Check if the bottom edge of the image is visible
+    if (imageBottomLeft.y() < 0 || imageBottomLeft.y() > height()) {
+        return;  // Image bottom edge not visible in widget
+    }
+
+    // Calculate the visible portion of the image (clamp to widget bounds)
+    int imageLeft = static_cast<int>(std::max(0.0, imageBottomLeft.x()));
+    int imageRight = static_cast<int>(std::min(static_cast<double>(width()), imageBottomRight.x()));
+
+    if (imageLeft >= imageRight) {
+        return;  // No visible horizontal range
+    }
+
+    // Ruler Y position - at the bottom edge of the image
+    int rulerY = static_cast<int>(imageBottomLeft.y());
+
+    // Ensure ruler doesn't go beyond widget
+    if (rulerY + m_rulerWidth > height()) {
+        return;  // Not enough space for ruler
+    }
+
+    // Draw ruler background - only within image bounds
+    QRect rulerRect(imageLeft, rulerY, imageRight - imageLeft, m_rulerWidth);
+    painter.fillRect(rulerRect, QColor(0, 0, 0, 180));
+
+    // Draw ruler top border (the line along image edge)
+    painter.setPen(QPen(m_rulerColor, 1));
+    painter.drawLine(imageLeft, rulerY, imageRight, rulerY);
+
+    // Calculate physical dimensions
+    double imageSizeMm = m_imageWidth * m_pixelSpacingX;
+
+    // Determine tick interval based on zoom
+    double tickInterval = calculateTickInterval();
+    double majorInterval = (tickInterval <= 5.0) ? 10.0 : 50.0;
+
+    // Set up font for labels
+    QFont font("Arial", FONT_SIZE);
+    painter.setFont(font);
+    QFontMetrics fm(font);
+
+    // Draw "cm" label at left of ruler (if space available)
+    if (imageLeft < width() - 30) {
+        painter.setPen(m_rulerColor);
+        QString unitLabel = "cm";
+        int unitX = imageLeft + 4;
+        int unitY = rulerY + (m_rulerWidth + fm.ascent()) / 2;
+        painter.drawText(unitX, unitY, unitLabel);
+    }
+
+    // Calculate total number of ticks (use integer math to avoid floating point issues)
+    int tickIntervalUm = static_cast<int>(tickInterval * 1000);  // Convert to micrometers
+    int majorIntervalUm = static_cast<int>(majorInterval * 1000);
+    int totalUm = static_cast<int>(imageSizeMm * 1000);
+
+    // Draw ticks from 0 to image width
+    for (int um = 0; um <= totalUm; um += tickIntervalUm) {
+        double mm = um / 1000.0;
+
+        // Convert mm position to image pixel position
+        double imageX = mm / m_pixelSpacingX;
+
+        // Transform to widget coordinates
+        QPointF widgetPos = transformToWidget(QPointF(imageX, m_imageHeight));
+
+        // Only draw ticks within the image bounds (in widget space)
+        if (widgetPos.x() < imageLeft || widgetPos.x() > imageRight) {
+            continue;
+        }
+
+        int x = static_cast<int>(widgetPos.x());
+        int tickLength;
+        bool drawLabel = false;
+
+        // Determine tick type using integer modulo (no floating point errors)
+        if (um % majorIntervalUm == 0) {
+            tickLength = MAJOR_TICK_LENGTH;
+            drawLabel = (um > 0);  // Don't label 0
+        } else if (um % 5000 == 0) {
+            // Medium tick (5mm = 5000um)
+            tickLength = MEDIUM_TICK_LENGTH;
+        } else {
+            tickLength = MINOR_TICK_LENGTH;
+        }
+
+        // Draw tick mark
+        painter.setPen(QPen(m_rulerColor, 1));
+        painter.drawLine(x, rulerY, x, rulerY + tickLength);
+
+        // Draw label at major ticks
+        if (drawLabel) {
+            int cm = um / 10000;  // 10000um = 1cm
+            QString label = QString::number(cm);
+
+            int textWidth = fm.horizontalAdvance(label);
+            int textX = x - textWidth / 2;
+            int textY = rulerY + tickLength + LABEL_MARGIN + fm.ascent();
+
+            // Draw text with shadow
+            painter.setPen(QColor(0, 0, 0));
+            painter.drawText(textX + 1, textY + 1, label);
+            painter.setPen(m_rulerColor);
+            painter.drawText(textX, textY, label);
+        }
+    }
+}
+
+} // namespace Etrek::ImageViewer::Widget

--- a/ImageViewer/Widget/EdgeRulerWidget.h
+++ b/ImageViewer/Widget/EdgeRulerWidget.h
@@ -1,0 +1,117 @@
+#ifndef EDGERULERWIDGET_H
+#define EDGERULERWIDGET_H
+
+#include <QWidget>
+#include <functional>
+#include "ImageViewerExport.h"
+
+namespace Etrek::ImageViewer::Widget {
+
+/**
+ * @class EdgeRulerWidget
+ * @brief Transparent overlay widget that renders measurement rulers on image edges.
+ *
+ * This widget displays calibrated rulers on the right and bottom edges of a
+ * medical image viewport. The rulers show physical measurements (mm/cm) based
+ * on the DICOM pixel spacing and update with zoom/pan operations.
+ *
+ * Features:
+ * - Right edge: Vertical ruler showing height measurements
+ * - Bottom edge: Horizontal ruler showing width measurements (optional)
+ * - Tick marks at 1mm intervals with major ticks at 1cm
+ * - Labels at centimeter intervals
+ * - Adapts to zoom and pan operations
+ */
+class IMAGEVIEWER_EXPORT EdgeRulerWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    using CoordinateTransform = std::function<QPointF(const QPointF&)>;
+
+    explicit EdgeRulerWidget(QWidget* parent = nullptr);
+    ~EdgeRulerWidget() override = default;
+
+    /**
+     * @brief Set the pixel spacing (mm per pixel).
+     * @param spacingX Horizontal spacing in mm/pixel
+     * @param spacingY Vertical spacing in mm/pixel
+     */
+    void setPixelSpacing(double spacingX, double spacingY);
+
+    /**
+     * @brief Set the image dimensions in pixels.
+     */
+    void setImageDimensions(int width, int height);
+
+    /**
+     * @brief Set the current zoom level.
+     * @param zoom Zoom factor (1.0 = 100%)
+     */
+    void setZoomLevel(double zoom);
+
+    /**
+     * @brief Set the function to convert image coords to widget coords.
+     */
+    void setImageToWidgetTransform(CoordinateTransform transform);
+
+    /**
+     * @brief Show/hide the horizontal (bottom) ruler.
+     */
+    void setShowHorizontalRuler(bool show);
+    bool showHorizontalRuler() const { return m_showHorizontal; }
+
+    /**
+     * @brief Show/hide the vertical (right) ruler.
+     */
+    void setShowVerticalRuler(bool show);
+    bool showVerticalRuler() const { return m_showVertical; }
+
+    /**
+     * @brief Set the ruler color.
+     */
+    void setRulerColor(const QColor& color);
+
+    /**
+     * @brief Set the ruler width in pixels.
+     */
+    void setRulerWidth(int width);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    void drawVerticalRuler(QPainter& painter);
+    void drawHorizontalRuler(QPainter& painter);
+    QPointF transformToWidget(const QPointF& imagePos) const;
+
+    /**
+     * @brief Calculate tick interval based on zoom level.
+     * Returns the interval in mm that gives reasonable tick spacing.
+     */
+    double calculateTickInterval() const;
+
+    CoordinateTransform m_imageToWidget;
+
+    double m_pixelSpacingX = 1.0;  // mm per pixel
+    double m_pixelSpacingY = 1.0;
+    int m_imageWidth = 0;
+    int m_imageHeight = 0;
+    double m_zoomLevel = 1.0;
+
+    bool m_showHorizontal = true;   // Bottom ruler
+    bool m_showVertical = true;     // Right ruler
+
+    QColor m_rulerColor{255, 255, 255};  // White
+    int m_rulerWidth = 25;  // Width of ruler area in pixels
+
+    // Visual constants
+    static constexpr int MINOR_TICK_LENGTH = 3;   // 1mm ticks
+    static constexpr int MEDIUM_TICK_LENGTH = 6;  // 5mm ticks
+    static constexpr int MAJOR_TICK_LENGTH = 10;  // 1cm ticks
+    static constexpr int FONT_SIZE = 9;
+    static constexpr int LABEL_MARGIN = 2;
+};
+
+} // namespace Etrek::ImageViewer::Widget
+
+#endif // EDGERULERWIDGET_H


### PR DESCRIPTION
Introduced the `EdgeRulerWidget` to display dynamic rulers on the edges of medical image viewports. The rulers adapt to zoom, pan, and image metadata, providing precise measurements in millimeters and centimeters.

Key changes:
- Added `EdgeRulerWidget` class with support for vertical and horizontal rulers, tick marks, and labels.
- Updated `ImageViewerPageDelegate` to initialize and manage edge rulers for up to four viewports.
- Enhanced overlay text formatting to include additional metadata (e.g., patient demographics, study info).
- Integrated edge ruler updates into zoom, reset, and image loading workflows.
- Ensured edge rulers are hidden by default and dynamically resized based on viewport state.

These changes improve the usability of the image viewer for medical professionals by providing accurate and context-aware measurement tools.


Closes #98 