### PR TITLE
Defer signal-slot setup in SystemSettingPageDelegate

### DIFF
--- a/Application/Delegate/SystemSettingPageDelegate.cpp
+++ b/Application/Delegate/SystemSettingPageDelegate.cpp
@@ -1,15 +1,28 @@
 #include "SystemSettingPageDelegate.h"
 #include "SystemSettingPage.h"
 
+#include <QTimer>
+
 namespace Etrek::Application::Delegate
 {
     SystemSettingPageDelegate::SystemSettingPageDelegate(SystemSettingPage* page, QObject* parent)
         : QObject(parent),
         m_page(page)
     {
-        connect(page, &SystemSettingPage::saveSettings, this, &SystemSettingPageDelegate::accept);
-        connect(page, &SystemSettingPage::applySettings, this, &SystemSettingPageDelegate::apply);
-        connect(page, &SystemSettingPage::closeSettings, this, &SystemSettingPageDelegate::reject);
+        // Deferred initialization to allow UI to settle first
+        QTimer::singleShot(0, this, &SystemSettingPageDelegate::onPageLoaded);
+    }
+
+    void SystemSettingPageDelegate::onPageLoaded()
+    {
+        setupConnections();
+    }
+
+    void SystemSettingPageDelegate::setupConnections()
+    {
+        connect(m_page, &SystemSettingPage::saveSettings, this, &SystemSettingPageDelegate::accept);
+        connect(m_page, &SystemSettingPage::applySettings, this, &SystemSettingPageDelegate::apply);
+        connect(m_page, &SystemSettingPage::closeSettings, this, &SystemSettingPageDelegate::reject);
     }
 
     SystemSettingPageDelegate::~SystemSettingPageDelegate() = default;

--- a/Application/Delegate/SystemSettingPageDelegate.h
+++ b/Application/Delegate/SystemSettingPageDelegate.h
@@ -32,7 +32,12 @@ public slots:
   void accept() override;
   void reject() override;
 
+private slots:
+  void onPageLoaded();
+
 private:
+  void setupConnections();
+
   SystemSettingPage *m_page;
   QVector<QPointer<QObject>> delegates;
 };


### PR DESCRIPTION
Refactored `SystemSettingPageDelegate` to use `QTimer::singleShot` for deferred initialization of signal-slot connections.

- Added `#include <QTimer>` to enable deferred setup.
- Moved signal-slot connections to a new `setupConnections` method.
- Introduced a new private slot `onPageLoaded` to handle deferred initialization.
- Updated `SystemSettingPageDelegate.h` to declare the new slot and method.

These changes ensure connections are established after the UI has settled, improving stability and predictability.

Closes #103 