### PR TITLE
feat: Add EntityStatusService for workflow status tracking

### DIFF
--- a/Application/Delegate/WorkListPageDelegate.cpp
+++ b/Application/Delegate/WorkListPageDelegate.cpp
@@ -12,11 +12,14 @@
 #include "AddPatientDialog.h"
 #include "LocalMwlRegistrationService.h"
 #include "IContextManager.h"
+#include "ISessionContext.h"
 #include "ExaminationContext.h"
 #include "WorklistFilterProxyModel.h"
 #include "ViewSelectionDialogBuilder.h"
 #include "ViewSelectionDialogDelegate.h"
 #include "DelegateParameter.h"
+#include "EntityStatusService.h"
+#include "EntityStatus.h"
 
 
 using namespace Etrek::Worklist::Repository;
@@ -40,7 +43,8 @@ namespace Etrek::Application::Delegate
         , dicomRepository(dicomRepository)
         , dicomTagRepository(dicomTagRepository)
         , dbConnection(dbConnection)
-        , contextManager(contextManager) {
+        , contextManager(contextManager)
+        , entityStatusService(std::make_shared<Etrek::Dicom::Service::EntityStatusService>(dicomRepository)) {
 
         baseModel = new QStandardItemModel(this);
         proxyModel = new WorklistFilterProxyModel(this);
@@ -118,6 +122,35 @@ namespace Etrek::Application::Delegate
             auto result = registrationService.registerPatient(patientData);
 
             if (result.isSuccess) {
+                // Track entity status for each created MWL entry
+                if (entityStatusService) {
+                    // Get user ID from session context
+                    int userId = -1;
+                    if (auto ctxMgr = contextManager.lock()) {
+                        if (auto sessionCtx = ctxMgr->sessionContext()) {
+                            if (auto user = sessionCtx->currentUser()) {
+                                userId = user->Id;
+                            }
+                        }
+                    }
+
+                    using namespace Etrek::Dicom::Data::Entity;
+                    for (const auto& entry : result.value) {
+                        auto statusResult = entityStatusService->scheduleEntity(
+                            EntityType::STUDY,
+                            entry.Id,
+                            userId,
+                            Priority::NORMAL);
+
+                        if (statusResult.isSuccess) {
+                            qDebug() << "[WorkListPageDelegate] Entity status set to SCHEDULED for entry:" << entry.Id;
+                        } else {
+                            qWarning() << "[WorkListPageDelegate] Failed to track entity status for entry:"
+                                       << entry.Id << "-" << statusResult.message;
+                        }
+                    }
+                }
+
                 // Success - show message and refresh the worklist
                 QString message = QString("Successfully registered patient with %1 MWL entry(ies).")
                     .arg(result.value.size());
@@ -700,7 +733,8 @@ namespace Etrek::Application::Delegate
                 qDebug() << "Selected Procedure ID:" << procedureId;
                 qDebug() << "Selected View IDs:" << viewIds;
 
-                // Update ExaminationContext with selected procedure and view IDs
+                // Get user ID from session context for status tracking
+                int userId = -1;
                 if (auto ctxMgr = contextManager.lock()) {
                     auto workflowCtx = ctxMgr->workflowContext("Examination");
                     auto examCtx = std::dynamic_pointer_cast<Etrek::Core::Context::ExaminationContext>(workflowCtx);
@@ -710,6 +744,13 @@ namespace Etrek::Application::Delegate
                         examCtx->setViewIds(viewIds);
                         qDebug() << "[WorkListPageDelegate] Updated ExaminationContext with procedure and views";
                     }
+
+                    // Get user ID from session context
+                    if (auto sessionCtx = ctxMgr->sessionContext()) {
+                        if (auto user = sessionCtx->currentUser()) {
+                            userId = user->Id;
+                        }
+                    }
                 }
 
                 // Update worklist status to IN_PROGRESS
@@ -718,6 +759,22 @@ namespace Etrek::Application::Delegate
                     qDebug() << "[WorkListPageDelegate] Updated worklist entry to IN_PROGRESS";
                 } else {
                     qWarning() << "[WorkListPageDelegate] Failed to update status:" << statusResult.message;
+                }
+
+                // Track entity status in entity_status table
+                if (entityStatusService) {
+                    using namespace Etrek::Dicom::Data::Entity;
+                    auto entityStatusResult = entityStatusService->startExamination(
+                        EntityType::STUDY,
+                        entryId,
+                        userId,
+                        Priority::NORMAL);
+
+                    if (entityStatusResult.isSuccess) {
+                        qDebug() << "[WorkListPageDelegate] Entity status set to IN_PROGRESS";
+                    } else {
+                        qWarning() << "[WorkListPageDelegate] Failed to track entity status:" << entityStatusResult.message;
+                    }
                 }
 
                 emit startExamination(entryId);

--- a/Application/Delegate/WorkListPageDelegate.h
+++ b/Application/Delegate/WorkListPageDelegate.h
@@ -17,6 +17,7 @@
 #include "DicomRepository.h"
 #include "DicomTagRepository.h"
 #include "PatientModel.h"
+#include "EntityStatusService.h"
 
 namespace Etrek::Context {
     class IContextManager;
@@ -105,6 +106,7 @@ namespace Etrek::Application::Delegate {
         std::shared_ptr<Etrek::Dicom::Repository::DicomTagRepository> dicomTagRepository;
         std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> dbConnection;
         std::weak_ptr<Etrek::Context::IContextManager> contextManager;
+        std::shared_ptr<Etrek::Dicom::Service::EntityStatusService> entityStatusService;
         QTimer* refreshTimer;
         bool modelInitialized = false;
 

--- a/Dicom/CMakeLists.txt
+++ b/Dicom/CMakeLists.txt
@@ -10,18 +10,21 @@ set(CMAKE_AUTOUIC_SEARCH_PATHS
     ${CMAKE_CURRENT_SOURCE_DIR}/Data
     ${CMAKE_CURRENT_SOURCE_DIR}/Delegate
     ${CMAKE_CURRENT_SOURCE_DIR}/Repository
+    ${CMAKE_CURRENT_SOURCE_DIR}/Service
 )
 
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Delegate/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Repository/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Service/*.cpp
 )
 
 file(GLOB_RECURSE HEADERS CONFIGURE_DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/*.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Delegate/*.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Repository/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Service/*.h
 
     ${COMMON_INCLUDE_DIR}/*.h
     ${COMMON_INCLUDE_DIR}/Dicom/*.h
@@ -54,6 +57,7 @@ target_include_directories(Dicom
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Util
     ${CMAKE_CURRENT_SOURCE_DIR}/Delegate
     ${CMAKE_CURRENT_SOURCE_DIR}/Repository
+    ${CMAKE_CURRENT_SOURCE_DIR}/Service
     ${COMMON_INCLUDE_DIR}/Dicom/
     ${COMMON_INCLUDE_DIR}/Dicom/Data/Entity
 )

--- a/Dicom/Service/EntityStatusService.cpp
+++ b/Dicom/Service/EntityStatusService.cpp
@@ -1,0 +1,160 @@
+#include "EntityStatusService.h"
+#include "DicomRepository.h"
+#include <QDateTime>
+
+namespace Etrek::Dicom::Service {
+
+    EntityStatusService::EntityStatusService(
+        std::shared_ptr<Etrek::Dicom::Repository::DicomRepository> repository,
+        QObject* parent)
+        : QObject(parent)
+        , m_repository(std::move(repository))
+    {
+    }
+
+    EntityStatusService::~EntityStatusService() = default;
+
+    Result<EntityStatus> EntityStatusService::startExamination(
+        EntityType entityType,
+        int entityId,
+        int userId,
+        Priority priority)
+    {
+        // Get current status to detect transition
+        auto currentResult = m_repository->getCurrentStatus(entityType, entityId);
+        std::optional<WorkflowStatus> oldStatus = std::nullopt;
+        if (currentResult.isSuccess && currentResult.value.has_value()) {
+            oldStatus = currentResult.value->Status;
+        }
+
+        EntityStatus status;
+        status.Type = entityType;
+        status.EntityId = entityId;
+        status.Status = WorkflowStatus::IN_PROGRESS;
+        status.PriorityLevel = priority;
+        status.AssignedTo = userId;
+        status.TransitionedBy = userId;
+        status.TransitionedAt = QDateTime::currentDateTime();
+
+        auto result = m_repository->insertEntityStatus(status);
+        if (result.isSuccess) {
+            emit statusChanged(entityType, entityId, oldStatus, WorkflowStatus::IN_PROGRESS);
+        }
+        return result;
+    }
+
+    Result<EntityStatus> EntityStatusService::scheduleEntity(
+        EntityType entityType,
+        int entityId,
+        int userId,
+        Priority priority)
+    {
+        EntityStatus status;
+        status.Type = entityType;
+        status.EntityId = entityId;
+        status.Status = WorkflowStatus::SCHEDULED;
+        status.PriorityLevel = priority;
+        status.AssignedTo = -1; // Not assigned yet
+        status.TransitionedBy = userId;
+        status.TransitionedAt = QDateTime::currentDateTime();
+
+        auto result = m_repository->insertEntityStatus(status);
+        if (result.isSuccess) {
+            emit statusChanged(entityType, entityId, std::nullopt, WorkflowStatus::SCHEDULED);
+        }
+        return result;
+    }
+
+    Result<EntityStatus> EntityStatusService::updateStatus(
+        EntityType entityType,
+        int entityId,
+        WorkflowStatus newStatus,
+        int userId,
+        const QString& reason,
+        const QString& notes)
+    {
+        // Get current status to detect transition
+        auto currentResult = m_repository->getCurrentStatus(entityType, entityId);
+        std::optional<WorkflowStatus> oldStatus = std::nullopt;
+        if (currentResult.isSuccess && currentResult.value.has_value()) {
+            oldStatus = currentResult.value->Status;
+        }
+
+        EntityStatus status;
+        status.Type = entityType;
+        status.EntityId = entityId;
+        status.Status = newStatus;
+        status.StatusReason = reason;
+        status.Notes = notes;
+        status.TransitionedBy = userId;
+        status.TransitionedAt = QDateTime::currentDateTime();
+
+        // Preserve assigned user if exists
+        if (currentResult.isSuccess && currentResult.value.has_value()) {
+            status.AssignedTo = currentResult.value->AssignedTo;
+            status.PriorityLevel = currentResult.value->PriorityLevel;
+        }
+
+        auto result = m_repository->insertEntityStatus(status);
+        if (result.isSuccess) {
+            emit statusChanged(entityType, entityId, oldStatus, newStatus);
+        }
+        return result;
+    }
+
+    Result<EntityStatus> EntityStatusService::completeExamination(
+        EntityType entityType,
+        int entityId,
+        int userId,
+        const QString& notes)
+    {
+        return updateStatus(entityType, entityId, WorkflowStatus::COMPLETED, userId, QString(), notes);
+    }
+
+    Result<EntityStatus> EntityStatusService::cancelExamination(
+        EntityType entityType,
+        int entityId,
+        int userId,
+        const QString& reason)
+    {
+        return updateStatus(entityType, entityId, WorkflowStatus::CANCELLED, userId, reason, QString());
+    }
+
+    Result<EntityStatus> EntityStatusService::abortExamination(
+        EntityType entityType,
+        int entityId,
+        int userId,
+        const QString& reason)
+    {
+        return updateStatus(entityType, entityId, WorkflowStatus::ABORTED, userId, reason, QString());
+    }
+
+    Result<std::optional<EntityStatus>> EntityStatusService::getCurrentStatus(
+        EntityType entityType,
+        int entityId) const
+    {
+        return m_repository->getCurrentStatus(entityType, entityId);
+    }
+
+    Result<QVector<EntityStatus>> EntityStatusService::getStatusHistory(
+        EntityType entityType,
+        int entityId) const
+    {
+        return m_repository->getStatusHistory(entityType, entityId);
+    }
+
+    Result<QVector<EntityStatus>> EntityStatusService::getEntitiesByStatus(
+        EntityType entityType,
+        WorkflowStatus status) const
+    {
+        return m_repository->getEntitiesByStatus(entityType, status);
+    }
+
+    Result<QVector<EntityStatus>> EntityStatusService::getAssignedEntities(
+        int userId,
+        WorkflowStatus status) const
+    {
+        return m_repository->getAssignedEntities(userId, status);
+    }
+
+} // namespace Etrek::Dicom::Service

--- a/Dicom/Service/EntityStatusService.h
+++ b/Dicom/Service/EntityStatusService.h
@@ -1,0 +1,184 @@
+#ifndef ENTITYSTATUSSERVICE_H
+#define ENTITYSTATUSSERVICE_H
+
+#include <QObject>
+#include <memory>
+#include <optional>
+#include "Result.h"
+#include "EntityStatus.h"
+
+namespace Etrek::Dicom::Repository {
+    class DicomRepository;
+}
+
+namespace Etrek::Dicom::Service {
+
+    using namespace Etrek::Dicom::Data::Entity;
+    using namespace Etrek::Specification;
+
+    /**
+     * @brief Service layer for managing entity workflow status.
+     *
+     * Provides high-level workflow operations (startExamination, completeExamination, etc.)
+     * on top of the DicomRepository's status tracking methods.
+     */
+    class EntityStatusService : public QObject
+    {
+        Q_OBJECT
+
+    public:
+        explicit EntityStatusService(
+            std::shared_ptr<Etrek::Dicom::Repository::DicomRepository> repository,
+            QObject* parent = nullptr);
+
+        ~EntityStatusService();
+
+        /**
+         * @brief Start an examination - sets status to IN_PROGRESS.
+         * @param entityType Type of entity (typically STUDY)
+         * @param entityId ID of the entity
+         * @param userId ID of the user starting the examination
+         * @param priority Optional priority level (defaults to NORMAL)
+         * @return Result with the created EntityStatus
+         */
+        Result<EntityStatus> startExamination(
+            EntityType entityType,
+            int entityId,
+            int userId,
+            Priority priority = Priority::NORMAL);
+
+        /**
+         * @brief Schedule a new entity - sets status to SCHEDULED.
+         * @param entityType Type of entity (typically STUDY)
+         * @param entityId ID of the entity
+         * @param userId ID of the user creating the schedule
+         * @param priority Optional priority level (defaults to NORMAL)
+         * @return Result with the created EntityStatus
+         */
+        Result<EntityStatus> scheduleEntity(
+            EntityType entityType,
+            int entityId,
+            int userId,
+            Priority priority = Priority::NORMAL);
+
+        /**
+         * @brief Update status with custom values.
+         * @param entityType Type of entity
+         * @param entityId ID of the entity
+         * @param newStatus New workflow status
+         * @param userId ID of the user making the change
+         * @param reason Optional reason for the status change
+         * @param notes Optional notes
+         * @return Result with the created EntityStatus
+         */
+        Result<EntityStatus> updateStatus(
+            EntityType entityType,
+            int entityId,
+            WorkflowStatus newStatus,
+            int userId,
+            const QString& reason = QString(),
+            const QString& notes = QString());
+
+        /**
+         * @brief Complete an examination - sets status to COMPLETED.
+         * @param entityType Type of entity
+         * @param entityId ID of the entity
+         * @param userId ID of the user completing the examination
+         * @param notes Optional completion notes
+         * @return Result with the created EntityStatus
+         */
+        Result<EntityStatus> completeExamination(
+            EntityType entityType,
+            int entityId,
+            int userId,
+            const QString& notes = QString());
+
+        /**
+         * @brief Cancel an examination - sets status to CANCELLED.
+         * @param entityType Type of entity
+         * @param entityId ID of the entity
+         * @param userId ID of the user cancelling
+         * @param reason Reason for cancellation
+         * @return Result with the created EntityStatus
+         */
+        Result<EntityStatus> cancelExamination(
+            EntityType entityType,
+            int entityId,
+            int userId,
+            const QString& reason);
+
+        /**
+         * @brief Abort an examination - sets status to ABORTED.
+         * @param entityType Type of entity
+         * @param entityId ID of the entity
+         * @param userId ID of the user aborting
+         * @param reason Reason for abortion
+         * @return Result with the created EntityStatus
+         */
+        Result<EntityStatus> abortExamination(
+            EntityType entityType,
+            int entityId,
+            int userId,
+            const QString& reason);
+
+        /**
+         * @brief Get the current status of an entity.
+         * @param entityType Type of entity
+         * @param entityId ID of the entity
+         * @return Result with optional EntityStatus (nullopt if no status exists)
+         */
+        Result<std::optional<EntityStatus>> getCurrentStatus(
+            EntityType entityType,
+            int entityId) const;
+
+        /**
+         * @brief Get full status history for an entity.
+         * @param entityType Type of entity
+         * @param entityId ID of the entity
+         * @return Result with vector of EntityStatus records
+         */
+        Result<QVector<EntityStatus>> getStatusHistory(
+            EntityType entityType,
+            int entityId) const;
+
+        /**
+         * @brief Get all entities with a specific status.
+         * @param entityType Type of entity
+         * @param status Status to filter by
+         * @return Result with vector of EntityStatus records
+         */
+        Result<QVector<EntityStatus>> getEntitiesByStatus(
+            EntityType entityType,
+            WorkflowStatus status) const;
+
+        /**
+         * @brief Get entities assigned to a specific user with a given status.
+         * @param userId User ID
+         * @param status Status to filter by
+         * @return Result with vector of EntityStatus records
+         */
+        Result<QVector<EntityStatus>> getAssignedEntities(
+            int userId,
+            WorkflowStatus status) const;
+
+    signals:
+        /**
+         * @brief Emitted when an entity's status changes.
+         * @param entityType Type of entity
+         * @param entityId ID of the entity
+         * @param oldStatus Previous status (nullopt if first status)
+         * @param newStatus New status
+         */
+        void statusChanged(
+            EntityType entityType,
+            int entityId,
+            std::optional<WorkflowStatus> oldStatus,
+            WorkflowStatus newStatus);
+
+    private:
+        std::shared_ptr<Etrek::Dicom::Repository::DicomRepository> m_repository;
+    };
+
+} // namespace Etrek::Dicom::Service
+
+#endif // ENTITYSTATUSSERVICE_H


### PR DESCRIPTION
- Create EntityStatusService in Dicom/Service/ with methods:
  - startExamination() - sets status to IN_PROGRESS
  - scheduleEntity() - sets status to SCHEDULED
  - completeExamination(), cancelExamination(), abortExamination()
  - getCurrentStatus(), getStatusHistory(), getEntitiesByStatus()
  - statusChanged signal for status notifications

- Integrate status tracking in WorkListPageDelegate:
  - Track IN_PROGRESS status when user double-clicks MWL item
  - Track SCHEDULED status when creating local patient

- Update Dicom/CMakeLists.txt to include Service directory

Closes #120, #121, #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)