### PR TITLE
Epic 4: RIS Procedure Code to View Mapping System

### DIFF
--- a/Application/Service/ApplicationService.cpp
+++ b/Application/Service/ApplicationService.cpp
@@ -17,6 +17,9 @@
 #include "ContextManager.h"
 #include "SessionContext.h"
 #include "IContextManager.h"
+#include "RisProcedureMappingRepository.h"
+#include "RisProcedureMappingService.h"
+#include "ScanProtocolRepository.h"
 
 #include "MainWindowDelegate.h"
 #include "ILaunchStrategy.h"
@@ -289,9 +292,18 @@ namespace Etrek::Application::Service
             [keepAlive = risQ](RisConnectionSetting*) mutable { keepAlive.clear(); }
         );
 
+        // Create the RIS procedure mapping service for code-to-view translation
+        auto mappingRepo = std::make_shared<Etrek::Worklist::Repository::RisProcedureMappingRepository>(
+            m_databaseConnectionSetting);
+        auto viewRepo = std::make_shared<Etrek::ScanProtocol::Repository::ScanProtocolRepository>(
+            m_databaseConnectionSetting);
+        auto mappingService = std::make_shared<Etrek::Worklist::Service::RisProcedureMappingService>(
+            mappingRepo, viewRepo);
+
         m_modalityWorklistManager = new ModalityWorklistManager(
             worklistRepository,
             risStd,
+            mappingService,
             this  // Qt parent manages lifetime
         );
 

--- a/Common/Include/Worklist/Data/Entity/RisProcedureMapping.h
+++ b/Common/Include/Worklist/Data/Entity/RisProcedureMapping.h
@@ -1,0 +1,41 @@
+#ifndef RISPROCEDUREMAPPING_H
+#define RISPROCEDUREMAPPING_H
+
+#include <QString>
+#include <QDateTime>
+
+namespace Etrek::Worklist::Data::Entity {
+
+/**
+ * @brief Represents a mapping from external RIS procedure code to internal view.
+ *
+ * This entity maps procedure codes received from RIS systems (via MWL C-FIND)
+ * to internal view IDs used in the application. Each RIS connection can have
+ * its own set of mappings since different RIS systems may use different
+ * coding schemes.
+ */
+class RisProcedureMapping {
+public:
+    int Id = -1;
+    QString ConnectionName;         // RIS connection identifier from settings
+    QString ExternalCode;           // Procedure code from RIS (e.g., "SRT2133", "CHEST-PA")
+    QString ExternalCodingScheme;   // Optional coding scheme (e.g., "SRT", "99LOCAL")
+    QString ExternalCodeMeaning;    // Human-readable description from RIS
+    int InternalViewId = -1;        // FK to views table
+    bool IsActive = true;
+    QString Notes;
+    QDateTime CreatedAt;
+    QDateTime UpdatedAt;
+
+    RisProcedureMapping() = default;
+
+    /**
+     * @brief Checks if this mapping is valid (has been persisted to database)
+     * @return true if the mapping has a valid database ID (Id >= 0)
+     */
+    bool isValid() const { return Id >= 0; }
+};
+
+} // namespace Etrek::Worklist::Data::Entity
+
+#endif // RISPROCEDUREMAPPING_H

--- a/Core/Script/setup_database.sql
+++ b/Core/Script/setup_database.sql
@@ -771,6 +771,28 @@ CREATE TABLE mwl_task_mapping (
     FOREIGN KEY (acquisition_id) REFERENCES acquisitions(id) ON DELETE CASCADE
 );
 
+-- Maps external RIS procedure codes to internal views
+-- Note: Uses connection_name as identifier since RIS connections are file-configured
+CREATE TABLE ris_procedure_mapping (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    connection_name VARCHAR(100) NOT NULL,     -- RIS connection name from settings
+    external_code VARCHAR(50) NOT NULL,        -- Code from RIS (e.g., "SRT2133", "CHEST-PA")
+    external_coding_scheme VARCHAR(20),        -- Optional: "SRT", "99LOCAL", etc.
+    external_code_meaning VARCHAR(255),        -- Human-readable description from RIS
+    internal_view_id INT NOT NULL,             -- FK to views table
+    is_active BOOLEAN DEFAULT TRUE,
+    notes TEXT,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP(6),
+
+    UNIQUE KEY uq_ris_code (connection_name, external_code),
+    FOREIGN KEY (internal_view_id) REFERENCES views(id) ON DELETE RESTRICT
+);
+
+-- Index for fast lookups during MWL import
+CREATE INDEX idx_ris_mapping_lookup
+ON ris_procedure_mapping (connection_name, external_code, is_active);
+
 -- **************[Insert DICOM tags into dicom_tags table]************************
 
 -- roles using system

--- a/Worklist/Connectivity/ModalityWorklistManager.cpp
+++ b/Worklist/Connectivity/ModalityWorklistManager.cpp
@@ -8,6 +8,7 @@
 #include "WorklistEntry.h"
 #include "WorklistProfile.h"
 #include "WorklistQueryService.h"
+#include "RisProcedureMappingService.h"
 
 
 
@@ -20,10 +21,12 @@ namespace Etrek::Worklist::Connectivity
 
     ModalityWorklistManager::ModalityWorklistManager(std::shared_ptr<WorklistRepository> repository,
         std::shared_ptr<RisConnectionSetting> settings,
+        std::shared_ptr<Etrek::Worklist::Service::RisProcedureMappingService> mappingService,
         QObject* parent)
         : QObject(parent),
         m_repository(repository),
-        settings(settings)
+        settings(settings),
+        m_mappingService(std::move(mappingService))
     {
         m_findTimer = new QTimer(this);
         m_findTimer->setInterval(m_refreshPeriodMs);
@@ -195,6 +198,29 @@ namespace Etrek::Worklist::Connectivity
                 remapedEntry.Status = ProcedureStepStatus::PENDING;
                 remapedEntry.CreatedAt = QDateTime::currentDateTime();
 
+                // Attempt to map the procedure code to an internal view
+                if (m_mappingService) {
+                    QString procedureCode = extractProcedureCode(entry);
+                    QString codeMeaning = extractProcedureCodeMeaning(entry);
+                    QString codingScheme = extractCodingScheme(entry);
+                    QString connectionName = settings->getName();
+
+                    if (!procedureCode.isEmpty()) {
+                        auto mappingResult = m_mappingService->mapProcedureCode(
+                            connectionName, procedureCode, codingScheme, codeMeaning);
+
+                        if (mappingResult.success) {
+                            qDebug() << "[ModalityWorklistManager] Procedure code" << procedureCode
+                                     << "mapped to view:" << mappingResult.viewName
+                                     << "(ID:" << mappingResult.viewId << ")";
+                            // TODO: Store mappingResult.viewId in the worklist entry
+                            // This requires extending WorklistEntry entity in Epic 5
+                        } else {
+                            qDebug() << "[ModalityWorklistManager]" << mappingResult.warningMessage;
+                        }
+                    }
+                }
+
                 m_repository->createWorklistEntry(remapedEntry);
             }
             else {
@@ -210,6 +236,47 @@ namespace Etrek::Worklist::Connectivity
                 // m_repository->UpdateWorklistEntry(remapedEntry);
             }
         }
+    }
+
+    QString ModalityWorklistManager::extractProcedureCode(const WorklistEntry& entry) const
+    {
+        // Look for Scheduled Protocol Code Sequence (0040,0008) > Code Value (0008,0100)
+        // The tag may be stored with parent reference or as a flat attribute
+        for (const auto& attr : entry.Attributes) {
+            // Code Value tag: (0008,0100) - may be nested under (0040,0008)
+            if (attr.Tag.GroupHex == 0x0008 && attr.Tag.ElementHex == 0x0100) {
+                if (!attr.TagValue.isEmpty()) {
+                    return attr.TagValue;
+                }
+            }
+        }
+        return QString();
+    }
+
+    QString ModalityWorklistManager::extractProcedureCodeMeaning(const WorklistEntry& entry) const
+    {
+        // Look for Code Meaning (0008,0104)
+        for (const auto& attr : entry.Attributes) {
+            if (attr.Tag.GroupHex == 0x0008 && attr.Tag.ElementHex == 0x0104) {
+                if (!attr.TagValue.isEmpty()) {
+                    return attr.TagValue;
+                }
+            }
+        }
+        return QString();
+    }
+
+    QString ModalityWorklistManager::extractCodingScheme(const WorklistEntry& entry) const
+    {
+        // Look for Coding Scheme Designator (0008,0102)
+        for (const auto& attr : entry.Attributes) {
+            if (attr.Tag.GroupHex == 0x0008 && attr.Tag.ElementHex == 0x0102) {
+                if (!attr.TagValue.isEmpty()) {
+                    return attr.TagValue;
+                }
+            }
+        }
+        return QString();
     }
 
 }

--- a/Worklist/Connectivity/ModalityWorklistManager.h
+++ b/Worklist/Connectivity/ModalityWorklistManager.h
@@ -25,6 +25,11 @@ namespace Etrek::Core::Data::Model
     class RisConnectionSetting;
 }
 
+namespace Etrek::Worklist::Service
+{
+    class RisProcedureMappingService;
+}
+
 namespace Etrek::Worklist::Connectivity
 {
 
@@ -37,6 +42,7 @@ namespace Etrek::Worklist::Connectivity
     public:
         explicit ModalityWorklistManager(std::shared_ptr<Etrek::Worklist::Repository::WorklistRepository> repository,
             std::shared_ptr<Etrek::Core::Data::Model::RisConnectionSetting> settings,
+            std::shared_ptr<Etrek::Worklist::Service::RisProcedureMappingService> mappingService = nullptr,
             QObject* parent = nullptr);
 
         void setActiveProfile(const Etrek::Worklist::Data::Entity::WorklistProfile& profile);
@@ -59,9 +65,13 @@ namespace Etrek::Worklist::Connectivity
 
     private:
         void prepareQueryService();  // Sets up thread & service safely
+        QString extractProcedureCode(const Etrek::Worklist::Data::Entity::WorklistEntry& entry) const;
+        QString extractProcedureCodeMeaning(const Etrek::Worklist::Data::Entity::WorklistEntry& entry) const;
+        QString extractCodingScheme(const Etrek::Worklist::Data::Entity::WorklistEntry& entry) const;
 
         std::shared_ptr<Etrek::Worklist::Repository::WorklistRepository> m_repository;
         std::shared_ptr<Etrek::Core::Data::Model::RisConnectionSetting> settings;
+        std::shared_ptr<Etrek::Worklist::Service::RisProcedureMappingService> m_mappingService;
 
         std::unique_ptr<WorklistQueryService> m_queryService;
         Etrek::Worklist::Data::Entity::WorklistProfile m_profile;

--- a/Worklist/Repository/RisProcedureMappingRepository.cpp
+++ b/Worklist/Repository/RisProcedureMappingRepository.cpp
@@ -1,0 +1,290 @@
+#include "RisProcedureMappingRepository.h"
+#include "LoggerProvider.h"
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QRandomGenerator>
+
+namespace Etrek::Worklist::Repository {
+
+    RisProcedureMappingRepository::RisProcedureMappingRepository(
+        std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> connectionSetting,
+        QObject* parent)
+        : QObject(parent)
+        , m_connectionSetting(std::move(connectionSetting))
+        , m_logger(Etrek::Core::Log::LoggerProvider::Instance().GetLogger("RisProcedureMappingRepository"))
+    {
+    }
+
+    QSqlDatabase RisProcedureMappingRepository::createConnection(const QString& connectionName) const
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase("QMYSQL", connectionName);
+        db.setHostName(m_connectionSetting->Host);
+        db.setPort(m_connectionSetting->Port);
+        db.setDatabaseName(m_connectionSetting->DatabaseName);
+        db.setUserName(m_connectionSetting->Username);
+        db.setPassword(m_connectionSetting->Password);
+        return db;
+    }
+
+    ent::RisProcedureMapping RisProcedureMappingRepository::mapRowToEntity(const QSqlQuery& query) const
+    {
+        ent::RisProcedureMapping mapping;
+        mapping.Id = query.value("id").toInt();
+        mapping.ConnectionName = query.value("connection_name").toString();
+        mapping.ExternalCode = query.value("external_code").toString();
+        mapping.ExternalCodingScheme = query.value("external_coding_scheme").toString();
+        mapping.ExternalCodeMeaning = query.value("external_code_meaning").toString();
+        mapping.InternalViewId = query.value("internal_view_id").toInt();
+        mapping.IsActive = query.value("is_active").toBool();
+        mapping.Notes = query.value("notes").toString();
+        mapping.CreatedAt = query.value("created_at").toDateTime();
+        mapping.UpdatedAt = query.value("updated_at").toDateTime();
+        return mapping;
+    }
+
+    Etrek::Specification::Result<ent::RisProcedureMapping> RisProcedureMappingRepository::insert(
+        ent::RisProcedureMapping& mapping)
+    {
+        const QString cx = "ris_mapping_insert_" + QString::number(QRandomGenerator::global()->generate());
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                const auto err = QString("Failed to open database: %1").arg(db.lastError().text());
+                m_logger->LogError(err);
+                return Etrek::Specification::Result<ent::RisProcedureMapping>::Failure(err);
+            }
+
+            QSqlQuery q(db);
+            q.prepare(R"(
+                INSERT INTO ris_procedure_mapping (
+                    connection_name, external_code, external_coding_scheme,
+                    external_code_meaning, internal_view_id, is_active, notes
+                ) VALUES (
+                    :connection_name, :external_code, :external_coding_scheme,
+                    :external_code_meaning, :internal_view_id, :is_active, :notes
+                )
+            )");
+
+            q.bindValue(":connection_name", mapping.ConnectionName);
+            q.bindValue(":external_code", mapping.ExternalCode);
+            q.bindValue(":external_coding_scheme", mapping.ExternalCodingScheme.isEmpty()
+                ? QVariant(QVariant::String) : mapping.ExternalCodingScheme);
+            q.bindValue(":external_code_meaning", mapping.ExternalCodeMeaning.isEmpty()
+                ? QVariant(QVariant::String) : mapping.ExternalCodeMeaning);
+            q.bindValue(":internal_view_id", mapping.InternalViewId);
+            q.bindValue(":is_active", mapping.IsActive);
+            q.bindValue(":notes", mapping.Notes.isEmpty() ? QVariant(QVariant::String) : mapping.Notes);
+
+            if (!q.exec()) {
+                const auto err = QString("Failed to insert RIS procedure mapping: %1").arg(q.lastError().text());
+                m_logger->LogError(err);
+                return Etrek::Specification::Result<ent::RisProcedureMapping>::Failure(err);
+            }
+
+            mapping.Id = q.lastInsertId().toInt();
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return Etrek::Specification::Result<ent::RisProcedureMapping>::Success(mapping);
+    }
+
+    Etrek::Specification::Result<bool> RisProcedureMappingRepository::update(
+        const ent::RisProcedureMapping& mapping)
+    {
+        const QString cx = "ris_mapping_update_" + QString::number(QRandomGenerator::global()->generate());
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                const auto err = QString("Failed to open database: %1").arg(db.lastError().text());
+                m_logger->LogError(err);
+                return Etrek::Specification::Result<bool>::Failure(err);
+            }
+
+            QSqlQuery q(db);
+            q.prepare(R"(
+                UPDATE ris_procedure_mapping SET
+                    connection_name = :connection_name,
+                    external_code = :external_code,
+                    external_coding_scheme = :external_coding_scheme,
+                    external_code_meaning = :external_code_meaning,
+                    internal_view_id = :internal_view_id,
+                    is_active = :is_active,
+                    notes = :notes
+                WHERE id = :id
+            )");
+
+            q.bindValue(":id", mapping.Id);
+            q.bindValue(":connection_name", mapping.ConnectionName);
+            q.bindValue(":external_code", mapping.ExternalCode);
+            q.bindValue(":external_coding_scheme", mapping.ExternalCodingScheme.isEmpty()
+                ? QVariant(QVariant::String) : mapping.ExternalCodingScheme);
+            q.bindValue(":external_code_meaning", mapping.ExternalCodeMeaning.isEmpty()
+                ? QVariant(QVariant::String) : mapping.ExternalCodeMeaning);
+            q.bindValue(":internal_view_id", mapping.InternalViewId);
+            q.bindValue(":is_active", mapping.IsActive);
+            q.bindValue(":notes", mapping.Notes.isEmpty() ? QVariant(QVariant::String) : mapping.Notes);
+
+            if (!q.exec()) {
+                const auto err = QString("Failed to update RIS procedure mapping: %1").arg(q.lastError().text());
+                m_logger->LogError(err);
+                return Etrek::Specification::Result<bool>::Failure(err);
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return Etrek::Specification::Result<bool>::Success(true);
+    }
+
+    Etrek::Specification::Result<bool> RisProcedureMappingRepository::remove(int id)
+    {
+        const QString cx = "ris_mapping_remove_" + QString::number(QRandomGenerator::global()->generate());
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                const auto err = QString("Failed to open database: %1").arg(db.lastError().text());
+                m_logger->LogError(err);
+                return Etrek::Specification::Result<bool>::Failure(err);
+            }
+
+            QSqlQuery q(db);
+            q.prepare("DELETE FROM ris_procedure_mapping WHERE id = :id");
+            q.bindValue(":id", id);
+
+            if (!q.exec()) {
+                const auto err = QString("Failed to delete RIS procedure mapping: %1").arg(q.lastError().text());
+                m_logger->LogError(err);
+                return Etrek::Specification::Result<bool>::Failure(err);
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return Etrek::Specification::Result<bool>::Success(true);
+    }
+
+    std::optional<ent::RisProcedureMapping> RisProcedureMappingRepository::getById(int id) const
+    {
+        const QString cx = "ris_mapping_getbyid_" + QString::number(QRandomGenerator::global()->generate());
+        std::optional<ent::RisProcedureMapping> result;
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                m_logger->LogError(QString("Failed to open database: %1").arg(db.lastError().text()));
+                return result;
+            }
+
+            QSqlQuery q(db);
+            q.prepare("SELECT * FROM ris_procedure_mapping WHERE id = :id");
+            q.bindValue(":id", id);
+
+            if (q.exec() && q.next()) {
+                result = mapRowToEntity(q);
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return result;
+    }
+
+    QVector<ent::RisProcedureMapping> RisProcedureMappingRepository::getByConnectionName(
+        const QString& connectionName) const
+    {
+        QVector<ent::RisProcedureMapping> mappings;
+        const QString cx = "ris_mapping_getbyconn_" + QString::number(QRandomGenerator::global()->generate());
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                m_logger->LogError(QString("Failed to open database: %1").arg(db.lastError().text()));
+                return mappings;
+            }
+
+            QSqlQuery q(db);
+            q.prepare("SELECT * FROM ris_procedure_mapping WHERE connection_name = :connection_name ORDER BY external_code");
+            q.bindValue(":connection_name", connectionName);
+
+            if (q.exec()) {
+                while (q.next()) {
+                    mappings.push_back(mapRowToEntity(q));
+                }
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return mappings;
+    }
+
+    QVector<ent::RisProcedureMapping> RisProcedureMappingRepository::getAllActive() const
+    {
+        QVector<ent::RisProcedureMapping> mappings;
+        const QString cx = "ris_mapping_getallactive_" + QString::number(QRandomGenerator::global()->generate());
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                m_logger->LogError(QString("Failed to open database: %1").arg(db.lastError().text()));
+                return mappings;
+            }
+
+            QSqlQuery q(db);
+            q.prepare("SELECT * FROM ris_procedure_mapping WHERE is_active = TRUE ORDER BY connection_name, external_code");
+
+            if (q.exec()) {
+                while (q.next()) {
+                    mappings.push_back(mapRowToEntity(q));
+                }
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return mappings;
+    }
+
+    std::optional<int> RisProcedureMappingRepository::findViewIdByExternalCode(
+        const QString& connectionName,
+        const QString& externalCode) const
+    {
+        auto mapping = findByExternalCode(connectionName, externalCode);
+        if (mapping.has_value()) {
+            return mapping->InternalViewId;
+        }
+        return std::nullopt;
+    }
+
+    std::optional<ent::RisProcedureMapping> RisProcedureMappingRepository::findByExternalCode(
+        const QString& connectionName,
+        const QString& externalCode) const
+    {
+        const QString cx = "ris_mapping_findbycode_" + QString::number(QRandomGenerator::global()->generate());
+        std::optional<ent::RisProcedureMapping> result;
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                m_logger->LogError(QString("Failed to open database: %1").arg(db.lastError().text()));
+                return result;
+            }
+
+            QSqlQuery q(db);
+            q.prepare(R"(
+                SELECT * FROM ris_procedure_mapping
+                WHERE connection_name = :connection_name
+                  AND external_code = :external_code
+                  AND is_active = TRUE
+                LIMIT 1
+            )");
+            q.bindValue(":connection_name", connectionName);
+            q.bindValue(":external_code", externalCode);
+
+            if (q.exec() && q.next()) {
+                result = mapRowToEntity(q);
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return result;
+    }
+
+} // namespace Etrek::Worklist::Repository

--- a/Worklist/Repository/RisProcedureMappingRepository.h
+++ b/Worklist/Repository/RisProcedureMappingRepository.h
@@ -1,0 +1,124 @@
+#ifndef RISPROCEDUREMAPPINGREPOSITORY_H
+#define RISPROCEDUREMAPPINGREPOSITORY_H
+
+#include <QObject>
+#include <QVector>
+#include <memory>
+#include <optional>
+#include <QSqlDatabase>
+#include "Result.h"
+#include "DatabaseConnectionSetting.h"
+#include "RisProcedureMapping.h"
+#include "AppLogger.h"
+
+namespace Etrek::Worklist::Repository {
+
+    namespace ent = Etrek::Worklist::Data::Entity;
+
+    /**
+     * @class RisProcedureMappingRepository
+     * @brief Provides data access for RIS procedure code to internal view mappings.
+     *
+     * This repository handles CRUD operations for ris_procedure_mapping table,
+     * enabling the system to map external RIS procedure codes to internal view IDs.
+     */
+    class RisProcedureMappingRepository : public QObject {
+        Q_OBJECT
+
+    public:
+        explicit RisProcedureMappingRepository(
+            std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> connectionSetting,
+            QObject* parent = nullptr);
+
+        virtual ~RisProcedureMappingRepository() = default;
+
+        // CRUD Operations
+
+        /**
+         * @brief Inserts a new procedure mapping.
+         * @param mapping The mapping to insert (Id will be set on success).
+         * @return Result containing the inserted mapping with Id set.
+         */
+        Etrek::Specification::Result<ent::RisProcedureMapping> insert(ent::RisProcedureMapping& mapping);
+
+        /**
+         * @brief Updates an existing procedure mapping.
+         * @param mapping The mapping to update.
+         * @return Result indicating success or failure.
+         */
+        Etrek::Specification::Result<bool> update(const ent::RisProcedureMapping& mapping);
+
+        /**
+         * @brief Removes a procedure mapping by ID.
+         * @param id The mapping ID to remove.
+         * @return Result indicating success or failure.
+         */
+        Etrek::Specification::Result<bool> remove(int id);
+
+        // Query Operations
+
+        /**
+         * @brief Retrieves a mapping by its ID.
+         * @param id The mapping ID.
+         * @return Optional containing the mapping if found.
+         */
+        std::optional<ent::RisProcedureMapping> getById(int id) const;
+
+        /**
+         * @brief Retrieves all mappings for a RIS connection.
+         * @param connectionName The RIS connection name.
+         * @return Vector of mappings for the connection.
+         */
+        QVector<ent::RisProcedureMapping> getByConnectionName(const QString& connectionName) const;
+
+        /**
+         * @brief Retrieves all active mappings.
+         * @return Vector of all active mappings.
+         */
+        QVector<ent::RisProcedureMapping> getAllActive() const;
+
+        // Key lookup for MWL import
+
+        /**
+         * @brief Finds the internal view ID for an external procedure code.
+         * @param connectionName The RIS connection name.
+         * @param externalCode The external procedure code from RIS.
+         * @return Optional containing the internal view ID if mapping exists.
+         */
+        std::optional<int> findViewIdByExternalCode(
+            const QString& connectionName,
+            const QString& externalCode) const;
+
+        /**
+         * @brief Finds the full mapping for an external procedure code.
+         * @param connectionName The RIS connection name.
+         * @param externalCode The external procedure code from RIS.
+         * @return Optional containing the full mapping if found.
+         */
+        std::optional<ent::RisProcedureMapping> findByExternalCode(
+            const QString& connectionName,
+            const QString& externalCode) const;
+
+    signals:
+        /**
+         * @brief Emitted when an unmapped procedure code is encountered.
+         * @param connectionName The RIS connection name.
+         * @param externalCode The unmapped procedure code.
+         * @param codeMeaning The code meaning if available.
+         */
+        void unmappedCodeEncountered(
+            const QString& connectionName,
+            const QString& externalCode,
+            const QString& codeMeaning);
+
+    private:
+        QSqlDatabase createConnection(const QString& connectionName) const;
+        ent::RisProcedureMapping mapRowToEntity(const QSqlQuery& query) const;
+
+        std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> m_connectionSetting;
+        std::shared_ptr<Etrek::Core::Log::AppLogger> m_logger;
+    };
+
+} // namespace Etrek::Worklist::Repository
+
+#endif // RISPROCEDUREMAPPINGREPOSITORY_H

--- a/Worklist/Service/RisProcedureMappingService.cpp
+++ b/Worklist/Service/RisProcedureMappingService.cpp
@@ -1,0 +1,145 @@
+#include "RisProcedureMappingService.h"
+#include "ScanProtocolRepository.h"
+#include <QDebug>
+
+namespace Etrek::Worklist::Service {
+
+    RisProcedureMappingService::RisProcedureMappingService(
+        std::shared_ptr<Etrek::Worklist::Repository::RisProcedureMappingRepository> mappingRepo,
+        std::shared_ptr<Etrek::ScanProtocol::Repository::ScanProtocolRepository> viewRepo,
+        QObject* parent)
+        : QObject(parent)
+        , m_mappingRepo(std::move(mappingRepo))
+        , m_viewRepo(std::move(viewRepo))
+    {
+    }
+
+    MappingResult RisProcedureMappingService::mapProcedureCode(
+        const QString& connectionName,
+        const QString& externalCode,
+        const QString& codingScheme,
+        const QString& codeMeaning)
+    {
+        MappingResult result;
+
+        if (externalCode.isEmpty()) {
+            result.warningMessage = "Empty procedure code provided";
+            return result;
+        }
+
+        // Look up the mapping
+        auto mapping = m_mappingRepo->findByExternalCode(connectionName, externalCode);
+
+        if (mapping.has_value()) {
+            result.success = true;
+            result.viewId = mapping->InternalViewId;
+
+            // Get view name from view repository
+            if (m_viewRepo) {
+                auto viewResult = m_viewRepo->getViewById(mapping->InternalViewId);
+                if (viewResult.isSuccess) {
+                    result.viewName = viewResult.value.Name;
+                }
+            }
+
+            qDebug() << "[RisProcedureMappingService] Mapped code" << externalCode
+                     << "to view ID" << result.viewId << "(" << result.viewName << ")";
+        } else {
+            // Code not mapped - emit signal and return warning
+            result.success = false;
+            result.warningMessage = QString("No mapping found for procedure code '%1' from connection '%2'")
+                .arg(externalCode, connectionName);
+
+            emit unmappedCodeEncountered(connectionName, externalCode, codeMeaning);
+
+            qDebug() << "[RisProcedureMappingService] Unmapped code:" << externalCode
+                     << "from" << connectionName;
+        }
+
+        return result;
+    }
+
+    QVector<SuggestedMapping> RisProcedureMappingService::suggestMappings(
+        const QString& externalCodeMeaning)
+    {
+        QVector<SuggestedMapping> suggestions;
+
+        if (externalCodeMeaning.isEmpty() || !m_viewRepo) {
+            return suggestions;
+        }
+
+        // Get all views and perform simple fuzzy matching
+        auto viewsResult = m_viewRepo->getAllViews();
+        if (!viewsResult.isSuccess) {
+            return suggestions;
+        }
+
+        QString searchTerm = externalCodeMeaning.toLower();
+        QStringList searchWords = searchTerm.split(QRegularExpression("\\W+"), Qt::SkipEmptyParts);
+
+        for (const auto& view : viewsResult.value) {
+            QString viewName = view.Name.toLower();
+            QString viewDesc = view.Description.toLower();
+
+            // Calculate simple match score
+            int matchCount = 0;
+            for (const QString& word : searchWords) {
+                if (word.length() < 3) continue;  // Skip short words
+
+                if (viewName.contains(word) || viewDesc.contains(word)) {
+                    matchCount++;
+                }
+            }
+
+            if (matchCount > 0) {
+                SuggestedMapping suggestion;
+                suggestion.viewId = view.Id;
+                suggestion.viewName = view.Name;
+                suggestion.confidenceScore = static_cast<double>(matchCount) / searchWords.size();
+                suggestions.push_back(suggestion);
+            }
+        }
+
+        // Sort by confidence score descending
+        std::sort(suggestions.begin(), suggestions.end(),
+            [](const SuggestedMapping& a, const SuggestedMapping& b) {
+                return a.confidenceScore > b.confidenceScore;
+            });
+
+        // Limit to top 5 suggestions
+        if (suggestions.size() > 5) {
+            suggestions.resize(5);
+        }
+
+        return suggestions;
+    }
+
+    Etrek::Specification::Result<ent::RisProcedureMapping> RisProcedureMappingService::createMapping(
+        ent::RisProcedureMapping& mapping)
+    {
+        return m_mappingRepo->insert(mapping);
+    }
+
+    Etrek::Specification::Result<bool> RisProcedureMappingService::updateMapping(
+        const ent::RisProcedureMapping& mapping)
+    {
+        return m_mappingRepo->update(mapping);
+    }
+
+    Etrek::Specification::Result<bool> RisProcedureMappingService::deleteMapping(int mappingId)
+    {
+        return m_mappingRepo->remove(mappingId);
+    }
+
+    QVector<ent::RisProcedureMapping> RisProcedureMappingService::getMappingsForConnection(
+        const QString& connectionName)
+    {
+        return m_mappingRepo->getByConnectionName(connectionName);
+    }
+
+    QVector<ent::RisProcedureMapping> RisProcedureMappingService::getAllMappings()
+    {
+        return m_mappingRepo->getAllActive();
+    }
+
+} // namespace Etrek::Worklist::Service

--- a/Worklist/Service/RisProcedureMappingService.h
+++ b/Worklist/Service/RisProcedureMappingService.h
@@ -1,0 +1,146 @@
+#ifndef ETREK_WORKLIST_SERVICE_RISPROCEDUREMAPPINGSERVICE_H
+#define ETREK_WORKLIST_SERVICE_RISPROCEDUREMAPPINGSERVICE_H
+
+#include <QObject>
+#include <memory>
+#include <optional>
+#include "Result.h"
+#include "RisProcedureMapping.h"
+#include "RisProcedureMappingRepository.h"
+
+namespace Etrek::ScanProtocol::Repository {
+    class ScanProtocolRepository;
+}
+
+namespace Etrek::Worklist::Service {
+
+    namespace ent = Etrek::Worklist::Data::Entity;
+
+    /**
+     * @brief Result of a procedure code mapping lookup
+     */
+    struct MappingResult {
+        bool success = false;
+        int viewId = -1;
+        QString viewName;
+        QString warningMessage;
+    };
+
+    /**
+     * @brief Suggested mapping based on code meaning similarity
+     */
+    struct SuggestedMapping {
+        int viewId;
+        QString viewName;
+        double confidenceScore;  // 0.0 to 1.0
+    };
+
+    /**
+     * @brief Service for managing RIS procedure code to view mappings.
+     *
+     * This service provides:
+     * - Core mapping lookup for MWL import flow
+     * - Unmapped code tracking and notification
+     * - Mapping suggestions based on code meaning
+     */
+    class RisProcedureMappingService : public QObject {
+        Q_OBJECT
+
+    public:
+        explicit RisProcedureMappingService(
+            std::shared_ptr<Etrek::Worklist::Repository::RisProcedureMappingRepository> mappingRepo,
+            std::shared_ptr<Etrek::ScanProtocol::Repository::ScanProtocolRepository> viewRepo,
+            QObject* parent = nullptr);
+
+        virtual ~RisProcedureMappingService() = default;
+
+        /**
+         * @brief Maps an external procedure code to an internal view.
+         *
+         * This is the core function used during MWL import to translate
+         * RIS procedure codes to internal view IDs.
+         *
+         * @param connectionName The RIS connection name.
+         * @param externalCode The procedure code from RIS.
+         * @param codingScheme Optional coding scheme (e.g., "SRT").
+         * @param codeMeaning Optional human-readable code meaning.
+         * @return MappingResult with view info if found, or warning if unmapped.
+         */
+        MappingResult mapProcedureCode(
+            const QString& connectionName,
+            const QString& externalCode,
+            const QString& codingScheme = QString(),
+            const QString& codeMeaning = QString());
+
+        /**
+         * @brief Suggests possible mappings based on code meaning.
+         *
+         * Uses fuzzy matching on view names to suggest possible mappings
+         * for unmapped codes.
+         *
+         * @param externalCodeMeaning The human-readable code meaning from RIS.
+         * @return Vector of suggested mappings sorted by confidence.
+         */
+        QVector<SuggestedMapping> suggestMappings(const QString& externalCodeMeaning);
+
+        /**
+         * @brief Creates a new mapping.
+         * @param mapping The mapping to create.
+         * @return Result with created mapping or error.
+         */
+        Etrek::Specification::Result<ent::RisProcedureMapping> createMapping(
+            ent::RisProcedureMapping& mapping);
+
+        /**
+         * @brief Updates an existing mapping.
+         * @param mapping The mapping to update.
+         * @return Result indicating success or failure.
+         */
+        Etrek::Specification::Result<bool> updateMapping(
+            const ent::RisProcedureMapping& mapping);
+
+        /**
+         * @brief Deletes a mapping.
+         * @param mappingId The mapping ID to delete.
+         * @return Result indicating success or failure.
+         */
+        Etrek::Specification::Result<bool> deleteMapping(int mappingId);
+
+        /**
+         * @brief Gets all mappings for a connection.
+         * @param connectionName The RIS connection name.
+         * @return Vector of mappings.
+         */
+        QVector<ent::RisProcedureMapping> getMappingsForConnection(
+            const QString& connectionName);
+
+        /**
+         * @brief Gets all active mappings.
+         * @return Vector of all active mappings.
+         */
+        QVector<ent::RisProcedureMapping> getAllMappings();
+
+    signals:
+        /**
+         * @brief Emitted when an unmapped procedure code is encountered.
+         *
+         * Connect to this signal to track unmapped codes for later
+         * configuration by administrators.
+         *
+         * @param connectionName The RIS connection name.
+         * @param externalCode The unmapped procedure code.
+         * @param codeMeaning The code meaning if available.
+         */
+        void unmappedCodeEncountered(
+            const QString& connectionName,
+            const QString& externalCode,
+            const QString& codeMeaning);
+
+    private:
+        std::shared_ptr<Etrek::Worklist::Repository::RisProcedureMappingRepository> m_mappingRepo;
+        std::shared_ptr<Etrek::ScanProtocol::Repository::ScanProtocolRepository> m_viewRepo;
+    };
+
+} // namespace Etrek::Worklist::Service
+
+#endif // ETREK_WORKLIST_SERVICE_RISPROCEDUREMAPPINGSERVICE_H


### PR DESCRIPTION
## Summary

Implements the core infrastructure for mapping external RIS procedure codes to internal views during MWL import (Issues #126, #127, #128, #129).

- **Database Schema (#126)**: Added `ris_procedure_mapping` table with unique constraint on connection_name + external_code
- **Entity & Repository (#127)**: Created `RisProcedureMapping` entity and `RisProcedureMappingRepository` with CRUD and lookup operations
- **Service Layer (#128)**: Implemented `RisProcedureMappingService` with procedure code mapping and fuzzy suggestion capabilities
- **MWL Integration (#129)**: Integrated mapping service into `ModalityWorklistManager` to map procedure codes during worklist import

### Key Features
- Supports per-RIS-connection procedure code mappings
- Extracts Code Value (0008,0100), Code Meaning (0008,0104), and Coding Scheme (0008,0102) from DICOM attributes
- Emits signal for unmapped codes to enable future admin notification
- Provides fuzzy matching suggestions based on code meaning

### Note
Issue #130 (Configuration UI) is deferred as it requires significant UI work.

## Test plan
- [ ] Verify database migration creates ris_procedure_mapping table
- [ ] Test procedure code lookup returns correct view mapping
- [ ] Verify unmapped codes emit appropriate signal
- [ ] Test fuzzy suggestions return relevant view matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)