### PR TITLE
Epic 5: MWL Task Mapping Repository and Integration

### DIFF
--- a/Application/Builder/ExamPageBuilder.cpp
+++ b/Application/Builder/ExamPageBuilder.cpp
@@ -3,6 +3,7 @@
 #include "DicomRepository.h"
 #include "ScanProtocolRepository.h"
 #include "DeviceRepository.h"
+#include "MwlTaskMappingRepository.h"
 
 namespace Etrek::Application::Delegate {
 
@@ -41,6 +42,11 @@ ExamPageBuilder::build(const DelegateParameter& params,
         nullptr  // QObject parent
     );
 
+    auto mwlTaskMappingRepo = std::make_shared<Etrek::Dicom::Repository::MwlTaskMappingRepository>(
+        params.dbConnection,
+        nullptr  // QObject parent
+    );
+
     // Create the delegate with all dependencies
     auto* delegate = new ExamPageDelegate(
         page,
@@ -48,6 +54,7 @@ ExamPageBuilder::build(const DelegateParameter& params,
         dicomRepo,
         scanProtocolRepo,
         deviceRepo,
+        mwlTaskMappingRepo,
         params.dbConnection,
         params.contextManager,
         parentDelegate

--- a/Application/Delegate/ExamPageDelegate.cpp
+++ b/Application/Delegate/ExamPageDelegate.cpp
@@ -4,6 +4,8 @@
 #include "DicomRepository.h"
 #include "ScanProtocolRepository.h"
 #include "DeviceRepository.h"
+#include "MwlTaskMappingRepository.h"
+#include "MwlTaskMapping.h"
 #include "IContextManager.h"
 #include "ExaminationContext.h"
 #include "DatabaseConnectionSetting.h"
@@ -56,6 +58,7 @@ ExamPageDelegate::ExamPageDelegate(
     std::shared_ptr<Etrek::Dicom::Repository::DicomRepository> dicomRepo,
     std::shared_ptr<Etrek::ScanProtocol::Repository::ScanProtocolRepository> scanProtocolRepo,
     std::shared_ptr<Etrek::Device::Repository::DeviceRepository> deviceRepo,
+    std::shared_ptr<Etrek::Dicom::Repository::MwlTaskMappingRepository> mwlTaskMappingRepo,
     std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> dbConnection,
     std::weak_ptr<Etrek::Context::IContextManager> contextManager,
     QObject* parent)
@@ -65,6 +68,7 @@ ExamPageDelegate::ExamPageDelegate(
     , m_dicomRepo(dicomRepo)
     , m_scanProtocolRepo(scanProtocolRepo)
     , m_deviceRepo(deviceRepo)
+    , m_mwlTaskMappingRepo(mwlTaskMappingRepo)
     , m_dbConnection(dbConnection)
     , m_contextManager(contextManager)
 {
@@ -134,6 +138,26 @@ void ExamPageDelegate::accept()
     // Mark examination as complete
     if (m_examinationContext) {
         m_examinationContext->markComplete();
+    }
+
+    // Create MWL task mapping to link worklist entry to DICOM objects
+    if (m_mwlTaskMappingRepo && m_worklistEntry.Id >= 0 && m_studyId >= 0) {
+        Etrek::Dicom::Data::Entity::MwlTaskMapping mapping;
+        mapping.MwlEntryId = m_worklistEntry.Id;
+        mapping.ProcedureId = m_procedure.Id;
+        mapping.StudyId = m_studyId;
+        mapping.SeriesId = m_seriesIds.isEmpty() ? -1 : m_seriesIds.first();
+        // TODO: Track ImagesId, SopCommonId, AcquisitionId when image acquisition is fully implemented
+        mapping.ImagesId = -1;
+        mapping.SopCommonId = -1;
+        mapping.AcquisitionId = -1;
+
+        auto result = m_mwlTaskMappingRepo->createMapping(mapping);
+        if (result.isSuccess) {
+            qDebug() << "[ExamPageDelegate] MWL task mapping created successfully";
+        } else {
+            qDebug() << "[ExamPageDelegate] Failed to create MWL task mapping:" << result.message;
+        }
     }
 
     // Update worklist status to COMPLETED

--- a/Application/Delegate/ExamPageDelegate.h
+++ b/Application/Delegate/ExamPageDelegate.h
@@ -47,6 +47,7 @@ namespace Etrek::Worklist::Repository {
 
 namespace Etrek::Dicom::Repository {
     class DicomRepository;
+    class MwlTaskMappingRepository;
 }
 
 namespace Etrek::ScanProtocol::Repository {
@@ -95,6 +96,7 @@ public:
         std::shared_ptr<Etrek::Dicom::Repository::DicomRepository> dicomRepo,
         std::shared_ptr<Etrek::ScanProtocol::Repository::ScanProtocolRepository> scanProtocolRepo,
         std::shared_ptr<Etrek::Device::Repository::DeviceRepository> deviceRepo,
+        std::shared_ptr<Etrek::Dicom::Repository::MwlTaskMappingRepository> mwlTaskMappingRepo,
         std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> dbConnection,
         std::weak_ptr<Etrek::Context::IContextManager> contextManager,
         QObject* parent = nullptr
@@ -241,6 +243,7 @@ private:
     std::shared_ptr<Etrek::Dicom::Repository::DicomRepository> m_dicomRepo;
     std::shared_ptr<Etrek::ScanProtocol::Repository::ScanProtocolRepository> m_scanProtocolRepo;
     std::shared_ptr<Etrek::Device::Repository::DeviceRepository> m_deviceRepo;
+    std::shared_ptr<Etrek::Dicom::Repository::MwlTaskMappingRepository> m_mwlTaskMappingRepo;
     std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> m_dbConnection;
 
     // --- Context ---

--- a/Dicom/Data/Entity/MwlTaskMapping.h
+++ b/Dicom/Data/Entity/MwlTaskMapping.h
@@ -1,0 +1,63 @@
+#ifndef ETREK_DICOM_DATA_ENTITY_MWLTASKMAPPING_H
+#define ETREK_DICOM_DATA_ENTITY_MWLTASKMAPPING_H
+
+namespace Etrek::Dicom::Data::Entity {
+
+/**
+ * @brief Maps MWL entries to the DICOM objects created during examination.
+ *
+ * This entity links a worklist entry and procedure to all the DICOM records
+ * created during an examination: study, series, images, SOP common, and acquisition.
+ * This enables tracking the complete chain from worklist to final images.
+ */
+class MwlTaskMapping {
+public:
+    int MwlEntryId = -1;      // FK to mwl_entries
+    int ProcedureId = -1;     // FK to procedures (composite PK with MwlEntryId)
+    int StudyId = -1;         // FK to studies
+    int SeriesId = -1;        // FK to series
+    int ImagesId = -1;        // FK to images
+    int SopCommonId = -1;     // FK to sop_commons
+    int AcquisitionId = -1;   // FK to acquisitions
+
+    MwlTaskMapping() = default;
+
+    /**
+     * @brief Checks if this mapping has valid primary key values
+     * @return true if both MwlEntryId and ProcedureId are set
+     */
+    bool isValid() const { return MwlEntryId >= 0 && ProcedureId >= 0; }
+
+    /**
+     * @brief Checks if all required DICOM chain IDs are populated
+     * @return true if all foreign keys are set
+     */
+    bool isComplete() const {
+        return MwlEntryId >= 0 &&
+               ProcedureId >= 0 &&
+               StudyId >= 0 &&
+               SeriesId >= 0 &&
+               ImagesId >= 0 &&
+               SopCommonId >= 0 &&
+               AcquisitionId >= 0;
+    }
+};
+
+/**
+ * @brief Full DICOM chain lookup result from MWL to acquisition
+ */
+struct DicomChain {
+    int MwlEntryId = -1;
+    int ProcedureId = -1;
+    int StudyId = -1;
+    int SeriesId = -1;
+    int ImageId = -1;
+    int SopCommonId = -1;
+    int AcquisitionId = -1;
+
+    bool isValid() const { return MwlEntryId >= 0 && StudyId >= 0; }
+};
+
+} // namespace Etrek::Dicom::Data::Entity
+
+#endif // ETREK_DICOM_DATA_ENTITY_MWLTASKMAPPING_H

--- a/Dicom/Repository/MwlTaskMappingRepository.cpp
+++ b/Dicom/Repository/MwlTaskMappingRepository.cpp
@@ -1,0 +1,257 @@
+#include "MwlTaskMappingRepository.h"
+#include "LoggerProvider.h"
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QRandomGenerator>
+
+namespace Etrek::Dicom::Repository {
+
+    using Etrek::Specification::Result;
+    using Etrek::Dicom::Data::Entity::MwlTaskMapping;
+    using Etrek::Dicom::Data::Entity::DicomChain;
+
+    MwlTaskMappingRepository::MwlTaskMappingRepository(
+        std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> connectionSetting,
+        QObject* parent)
+        : QObject(parent)
+        , m_connectionSetting(std::move(connectionSetting))
+        , m_logger(Etrek::Core::Log::LoggerProvider::Instance().GetLogger("MwlTaskMappingRepository"))
+    {
+    }
+
+    QSqlDatabase MwlTaskMappingRepository::createConnection(const QString& connectionName) const
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase("QMYSQL", connectionName);
+        db.setHostName(m_connectionSetting->Host);
+        db.setPort(m_connectionSetting->Port);
+        db.setDatabaseName(m_connectionSetting->DatabaseName);
+        db.setUserName(m_connectionSetting->Username);
+        db.setPassword(m_connectionSetting->Password);
+        return db;
+    }
+
+    MwlTaskMapping MwlTaskMappingRepository::mapRowToEntity(const QSqlQuery& query) const
+    {
+        MwlTaskMapping mapping;
+        mapping.MwlEntryId = query.value("mwl_entry_id").toInt();
+        mapping.ProcedureId = query.value("procedure_id").toInt();
+        mapping.StudyId = query.value("study_id").toInt();
+        mapping.SeriesId = query.value("series_id").toInt();
+        mapping.ImagesId = query.value("images_id").toInt();
+        mapping.SopCommonId = query.value("sop_common_id").toInt();
+        mapping.AcquisitionId = query.value("acquisition_id").toInt();
+        return mapping;
+    }
+
+    Result<bool> MwlTaskMappingRepository::createMapping(const MwlTaskMapping& mapping)
+    {
+        const QString cx = "mwl_task_create_" + QString::number(QRandomGenerator::global()->generate());
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                const auto err = QString("Failed to open database: %1").arg(db.lastError().text());
+                m_logger->LogError(err);
+                return Result<bool>::Failure(err);
+            }
+
+            QSqlQuery q(db);
+            q.prepare(R"(
+                INSERT INTO mwl_task_mapping (
+                    mwl_entry_id, procedure_id, study_id, series_id,
+                    images_id, sop_common_id, acquisition_id
+                ) VALUES (
+                    :mwl_entry_id, :procedure_id, :study_id, :series_id,
+                    :images_id, :sop_common_id, :acquisition_id
+                )
+            )");
+
+            q.bindValue(":mwl_entry_id", mapping.MwlEntryId);
+            q.bindValue(":procedure_id", mapping.ProcedureId);
+            q.bindValue(":study_id", mapping.StudyId);
+            q.bindValue(":series_id", mapping.SeriesId);
+            q.bindValue(":images_id", mapping.ImagesId);
+            q.bindValue(":sop_common_id", mapping.SopCommonId);
+            q.bindValue(":acquisition_id", mapping.AcquisitionId);
+
+            if (!q.exec()) {
+                const auto err = QString("Failed to create MWL task mapping: %1").arg(q.lastError().text());
+                m_logger->LogError(err);
+                return Result<bool>::Failure(err);
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return Result<bool>::Success(true);
+    }
+
+    QVector<MwlTaskMapping> MwlTaskMappingRepository::getMappingsByMwlEntry(int mwlEntryId) const
+    {
+        QVector<MwlTaskMapping> mappings;
+        const QString cx = "mwl_task_getbymwl_" + QString::number(QRandomGenerator::global()->generate());
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                m_logger->LogError(QString("Failed to open database: %1").arg(db.lastError().text()));
+                return mappings;
+            }
+
+            QSqlQuery q(db);
+            q.prepare("SELECT * FROM mwl_task_mapping WHERE mwl_entry_id = :mwl_entry_id ORDER BY procedure_id");
+            q.bindValue(":mwl_entry_id", mwlEntryId);
+
+            if (q.exec()) {
+                while (q.next()) {
+                    mappings.push_back(mapRowToEntity(q));
+                }
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return mappings;
+    }
+
+    std::optional<MwlTaskMapping> MwlTaskMappingRepository::getMappingByStudy(int studyId) const
+    {
+        const QString cx = "mwl_task_getbystudy_" + QString::number(QRandomGenerator::global()->generate());
+        std::optional<MwlTaskMapping> result;
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                m_logger->LogError(QString("Failed to open database: %1").arg(db.lastError().text()));
+                return result;
+            }
+
+            QSqlQuery q(db);
+            q.prepare("SELECT * FROM mwl_task_mapping WHERE study_id = :study_id LIMIT 1");
+            q.bindValue(":study_id", studyId);
+
+            if (q.exec() && q.next()) {
+                result = mapRowToEntity(q);
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return result;
+    }
+
+    std::optional<MwlTaskMapping> MwlTaskMappingRepository::getMappingByKey(int mwlEntryId, int procedureId) const
+    {
+        const QString cx = "mwl_task_getbykey_" + QString::number(QRandomGenerator::global()->generate());
+        std::optional<MwlTaskMapping> result;
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                m_logger->LogError(QString("Failed to open database: %1").arg(db.lastError().text()));
+                return result;
+            }
+
+            QSqlQuery q(db);
+            q.prepare(R"(
+                SELECT * FROM mwl_task_mapping
+                WHERE mwl_entry_id = :mwl_entry_id AND procedure_id = :procedure_id
+            )");
+            q.bindValue(":mwl_entry_id", mwlEntryId);
+            q.bindValue(":procedure_id", procedureId);
+
+            if (q.exec() && q.next()) {
+                result = mapRowToEntity(q);
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return result;
+    }
+
+    std::optional<DicomChain> MwlTaskMappingRepository::getFullChainByMwl(int mwlEntryId, int procedureId) const
+    {
+        auto mapping = getMappingByKey(mwlEntryId, procedureId);
+        if (!mapping.has_value()) {
+            return std::nullopt;
+        }
+
+        DicomChain chain;
+        chain.MwlEntryId = mapping->MwlEntryId;
+        chain.ProcedureId = mapping->ProcedureId;
+        chain.StudyId = mapping->StudyId;
+        chain.SeriesId = mapping->SeriesId;
+        chain.ImageId = mapping->ImagesId;
+        chain.SopCommonId = mapping->SopCommonId;
+        chain.AcquisitionId = mapping->AcquisitionId;
+        return chain;
+    }
+
+    Result<bool> MwlTaskMappingRepository::updateMapping(const MwlTaskMapping& mapping)
+    {
+        const QString cx = "mwl_task_update_" + QString::number(QRandomGenerator::global()->generate());
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                const auto err = QString("Failed to open database: %1").arg(db.lastError().text());
+                m_logger->LogError(err);
+                return Result<bool>::Failure(err);
+            }
+
+            QSqlQuery q(db);
+            q.prepare(R"(
+                UPDATE mwl_task_mapping SET
+                    study_id = :study_id,
+                    series_id = :series_id,
+                    images_id = :images_id,
+                    sop_common_id = :sop_common_id,
+                    acquisition_id = :acquisition_id
+                WHERE mwl_entry_id = :mwl_entry_id AND procedure_id = :procedure_id
+            )");
+
+            q.bindValue(":mwl_entry_id", mapping.MwlEntryId);
+            q.bindValue(":procedure_id", mapping.ProcedureId);
+            q.bindValue(":study_id", mapping.StudyId);
+            q.bindValue(":series_id", mapping.SeriesId);
+            q.bindValue(":images_id", mapping.ImagesId);
+            q.bindValue(":sop_common_id", mapping.SopCommonId);
+            q.bindValue(":acquisition_id", mapping.AcquisitionId);
+
+            if (!q.exec()) {
+                const auto err = QString("Failed to update MWL task mapping: %1").arg(q.lastError().text());
+                m_logger->LogError(err);
+                return Result<bool>::Failure(err);
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return Result<bool>::Success(true);
+    }
+
+    Result<bool> MwlTaskMappingRepository::deleteMapping(int mwlEntryId, int procedureId)
+    {
+        const QString cx = "mwl_task_delete_" + QString::number(QRandomGenerator::global()->generate());
+        {
+            QSqlDatabase db = createConnection(cx);
+            if (!db.open()) {
+                const auto err = QString("Failed to open database: %1").arg(db.lastError().text());
+                m_logger->LogError(err);
+                return Result<bool>::Failure(err);
+            }
+
+            QSqlQuery q(db);
+            q.prepare("DELETE FROM mwl_task_mapping WHERE mwl_entry_id = :mwl_entry_id AND procedure_id = :procedure_id");
+            q.bindValue(":mwl_entry_id", mwlEntryId);
+            q.bindValue(":procedure_id", procedureId);
+
+            if (!q.exec()) {
+                const auto err = QString("Failed to delete MWL task mapping: %1").arg(q.lastError().text());
+                m_logger->LogError(err);
+                return Result<bool>::Failure(err);
+            }
+
+            db.close();
+        }
+        QSqlDatabase::removeDatabase(cx);
+        return Result<bool>::Success(true);
+    }
+
+} // namespace Etrek::Dicom::Repository

--- a/Dicom/Repository/MwlTaskMappingRepository.h
+++ b/Dicom/Repository/MwlTaskMappingRepository.h
@@ -1,0 +1,97 @@
+#ifndef ETREK_DICOM_REPOSITORY_MWLTASKMAPPINGREPOSITORY_H
+#define ETREK_DICOM_REPOSITORY_MWLTASKMAPPINGREPOSITORY_H
+
+#include <QObject>
+#include <QVector>
+#include <memory>
+#include <optional>
+#include <QSqlDatabase>
+#include "Result.h"
+#include "DatabaseConnectionSetting.h"
+#include "MwlTaskMapping.h"
+#include "AppLogger.h"
+
+namespace Etrek::Dicom::Repository {
+
+    namespace ent = Etrek::Dicom::Data::Entity;
+
+    /**
+     * @class MwlTaskMappingRepository
+     * @brief Provides data access for MWL to DICOM task mapping records.
+     *
+     * This repository manages the mwl_task_mapping table which links
+     * worklist entries to all DICOM objects created during an examination.
+     */
+    class MwlTaskMappingRepository : public QObject {
+        Q_OBJECT
+
+    public:
+        explicit MwlTaskMappingRepository(
+            std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> connectionSetting,
+            QObject* parent = nullptr);
+
+        virtual ~MwlTaskMappingRepository() = default;
+
+        /**
+         * @brief Creates a new MWL task mapping record.
+         * @param mapping The mapping to create.
+         * @return Result indicating success or failure.
+         */
+        Etrek::Specification::Result<bool> createMapping(const ent::MwlTaskMapping& mapping);
+
+        /**
+         * @brief Gets all mappings for a specific MWL entry.
+         * @param mwlEntryId The MWL entry ID.
+         * @return Vector of mappings for the entry.
+         */
+        QVector<ent::MwlTaskMapping> getMappingsByMwlEntry(int mwlEntryId) const;
+
+        /**
+         * @brief Gets the mapping for a specific study.
+         * @param studyId The study ID.
+         * @return Optional containing the mapping if found.
+         */
+        std::optional<ent::MwlTaskMapping> getMappingByStudy(int studyId) const;
+
+        /**
+         * @brief Gets the mapping by primary key.
+         * @param mwlEntryId The MWL entry ID.
+         * @param procedureId The procedure ID.
+         * @return Optional containing the mapping if found.
+         */
+        std::optional<ent::MwlTaskMapping> getMappingByKey(int mwlEntryId, int procedureId) const;
+
+        /**
+         * @brief Gets the full DICOM chain for a worklist entry and procedure.
+         * @param mwlEntryId The MWL entry ID.
+         * @param procedureId The procedure ID.
+         * @return Optional containing the full chain if found.
+         */
+        std::optional<ent::DicomChain> getFullChainByMwl(int mwlEntryId, int procedureId) const;
+
+        /**
+         * @brief Updates an existing mapping.
+         * @param mapping The mapping to update.
+         * @return Result indicating success or failure.
+         */
+        Etrek::Specification::Result<bool> updateMapping(const ent::MwlTaskMapping& mapping);
+
+        /**
+         * @brief Deletes a mapping by primary key.
+         * @param mwlEntryId The MWL entry ID.
+         * @param procedureId The procedure ID.
+         * @return Result indicating success or failure.
+         */
+        Etrek::Specification::Result<bool> deleteMapping(int mwlEntryId, int procedureId);
+
+    private:
+        QSqlDatabase createConnection(const QString& connectionName) const;
+        ent::MwlTaskMapping mapRowToEntity(const QSqlQuery& query) const;
+
+        std::shared_ptr<Etrek::Core::Data::Model::DatabaseConnectionSetting> m_connectionSetting;
+        std::shared_ptr<Etrek::Core::Log::AppLogger> m_logger;
+    };
+
+} // namespace Etrek::Dicom::Repository
+
+#endif // ETREK_DICOM_REPOSITORY_MWLTASKMAPPINGREPOSITORY_H


### PR DESCRIPTION
## Summary

Implements the MWL task mapping infrastructure to link worklist entries to DICOM objects created during examinations (Issues #131, #132).

- **Entity (#131)**: Created `MwlTaskMapping` entity with fields for full DICOM chain (MWL entry -> study -> series -> images -> SOP -> acquisition)
- **Repository (#131)**: Implemented `MwlTaskMappingRepository` with CRUD and lookup operations
- **Integration (#132)**: Integrated mapping creation into `ExamPageDelegate.accept()` when examination completes

### Key Features
- Links MWL entries to created studies, series, and images
- Enables reverse lookup from study/series back to original worklist entry
- Provides `DicomChain` struct for full chain retrieval

### Note
Image/SOP/Acquisition IDs are currently placeholder (-1) until full image acquisition tracking is implemented. The existing database schema already has the `mwl_task_mapping` table defined.

## Test plan
- [ ] Verify entity creation with all required fields
- [ ] Test repository CRUD operations
- [ ] Complete examination workflow and verify mapping is created
- [ ] Test lookup by MWL entry ID and study ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)