### PR TITLE
Update GitHub CLI commands and enhance PR automation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -50,7 +50,10 @@
       "Bash(\"C:\\\\Program Files\\\\GitHub CLI\\\\gh.exe\" issue view 119 --json state,title)",
       "Bash(\"C:\\\\Program Files\\\\GitHub CLI\\\\gh.exe\" issue close 118 --comment \"Closed via PR #146 - Context injection audited and extended across delegates\")",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(\"C:\\\\Program Files\\\\GitHub CLI\\\\gh.exe\" pr create --title \"Epic 6: Runtime Parameter Persistence Infrastructure\" --body \"$\\(cat <<''EOF''\n## Summary\n\nImplements infrastructure for tracking and persisting runtime technique parameters \\(Issues #133, #134\\).\n\n### Schema Changes\n- Added technique parameter columns to `acquisitions` table:\n  - `kvp`, `ma`, `mas`, `exposure_time` - X-ray exposure parameters\n  - `sid` - Source to Image Distance  \n  - `patient_size_category` - Thin/Medium/Fat/Paediatric\n  - `exposure_index`, `target_exposure_index`, `deviation_index` - DICOM exposure indices\n\n### Parameter Tracking\n- Enhanced `onKvpChanged\\(\\)`, `onMaChanged\\(\\)`, `onTimeChanged\\(\\)`, `onDensityChanged\\(\\)` with before/after logging\n- Added comprehensive technique parameter logging in `onAcquisitionComplete\\(\\)`\n- Documented runtime value usage in `createImage\\(\\)` with detailed implementation TODO\n\n### Key Points\n- Handlers now update `m_currentTechnique` with runtime values\n- Logging clearly distinguishes protocol defaults from technician-modified values\n- Infrastructure ready for full persistence when Image/Acquisition repositories are implemented\n\nCloses #133\nCloses #134\n\n## Test plan\n- [ ] Verify schema migration adds new columns to acquisitions table\n- [ ] Monitor debug logs when changing KVP/mA/Time sliders\n- [ ] Verify logs show runtime values at acquisition completion\n\n🤖 Generated with [Claude Code]\\(https://claude.com/claude-code\\)\nEOF\n\\)\")",
+      "Bash(\"C:\\\\Program Files\\\\GitHub CLI\\\\gh.exe\" issue close 133 --comment \"Closed via PR #153 - Parameter tracking audit completed with enhanced logging\")",
+      "Bash(\"C:\\\\Program Files\\\\GitHub CLI\\\\gh.exe\" issue close 134 --comment \"Closed via PR #153 - Acquisitions schema updated and runtime value persistence infrastructure added\")"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
Enhanced Bash commands in `settings.local.json`:
- Added `pr create` command with detailed title, body, and test plan for runtime parameter persistence infrastructure.
- Included commands to close issues (#133, #134) with comments referencing PR #153, detailing schema updates and logging improvements.
- Improved automation and traceability for managing issues and pull requests.
- No functional changes to `git commit` or `git add` commands.