### PR TITLE
Fix missing User.h include in ContextAuditService

### DIFF
--- a/Core/Context/ContextAuditService.cpp
+++ b/Core/Context/ContextAuditService.cpp
@@ -4,6 +4,7 @@
 #include "ISessionContext.h"
 #include "IWorkflowContext.h"
 #include "IExaminationContext.h"
+#include "User.h"
 
 #include <QJsonObject>
 #include <QDebug>


### PR DESCRIPTION
## Summary

Fix build error caused by incomplete type `Etrek::Core::Data::Entity::User` in ContextAuditService.

## Problem

The code uses `std::optional<User>` which requires the complete type definition, but only a forward declaration was available.

## Fix

Add `#include "User.h"` to provide the full type definition.

## Test plan

- [ ] Build completes without C2139/C2027 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)